### PR TITLE
add spec/ feature docs, cover bash-completions and tui with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "ratatui",
  "rusqlite",
  "self_update",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ self_update = { workspace = true, optional = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,36 @@
+# Spec
+
+Every feature is documented here before or as it lands, with its status.
+
+## Feature status
+
+Status values: `done` (implemented and covered by tests), `pending` (documented,
+not yet built; the default), `research` (needs investigation or design before it
+can be built). Keep each row's status current with `spec.py set`.
+
+| Feature | Status | Spec |
+|---------|--------|------|
+| CLI Project Setup | done | [cli-project-setup.md](cli-project-setup.md) |
+| CLI Migration Management | done | [cli-migration-management.md](cli-migration-management.md) |
+| Database Shell | done | [database-shell.md](database-shell.md) |
+| Self Update | done | [self-update.md](self-update.md) |
+| Bash Completions | done | [bash-completions.md](bash-completions.md) |
+| Migration TUI | done | [migration-tui.md](migration-tui.md) |
+| Library Config API | done | [library-config-api.md](library-config-api.md) |
+| Migration Types | done | [migration-types.md](migration-types.md) |
+| Migrator API | done | [migrator-api.md](migrator-api.md) |
+| Settings Builders | done | [settings-builders.md](settings-builders.md) |
+| In-Memory SQLite | done | [in-memory-sqlite.md](in-memory-sqlite.md) |
+| Database Backends | done | [database-backends.md](database-backends.md) |
+| Config File and Env Resolution | done | [config-file-and-env-resolution.md](config-file-and-env-resolution.md) |
+| Error Handling API | done | [error-handling-api.md](error-handling-api.md) |
+| Distribution | done | [distribution.md](distribution.md) |
+
+## Conventions
+
+- Each normative statement carries a stable ID (e.g. `FEAT-1`, `API-3`). IDs are
+  append-only: retire an ID by marking it removed, never reuse the number.
+- Specs are document-first: a feature is documented (status `pending`, or
+  `research` if it needs design work) before implementation begins. Flip to
+  `done` only once implemented and verified.
+- Spec files are named `<slug>.md` and linked from the table above.

--- a/spec/bash-completions.md
+++ b/spec/bash-completions.md
@@ -1,0 +1,15 @@
+# Bash Completions
+
+self bash-completions subcommand generating or installing completion scripts.
+
+## BASHCO-1
+
+`migrant self bash-completions` writes a bash completion script to stdout.
+
+## BASHCO-2
+
+`migrant self bash-completions install --path <path>` writes the completion script to the
+given path.
+
+Coverage: `tests/bash_completions.rs` (BASHCO-1 stdout output; BASHCO-2 install to a path,
+plus declined-confirmation writes nothing). Implemented in `src/main.rs`/`src/cli.rs`.

--- a/spec/cli-migration-management.md
+++ b/spec/cli-migration-management.md
@@ -1,0 +1,31 @@
+# CLI Migration Management
+
+new, edit, list, apply, and redo subcommands for creating and running migrations.
+
+## CLIMIG-1
+
+`migrant new <tag>` generates a timestamped up/down migration file pair under the configured
+migration location.
+
+## CLIMIG-2
+
+`migrant edit <tag>` opens the migration's up file in `$EDITOR`; `--down` selects the down
+file instead.
+
+## CLIMIG-3
+
+`migrant list` displays all managed migrations with their applied status.
+
+## CLIMIG-4
+
+`migrant apply` applies the next unapplied migration. Flags: `--all` applies all remaining,
+`--down` reverses direction (unapplies), `--force` continues past SQL errors, `--fake` marks
+migrations applied/unapplied without executing their SQL.
+
+## CLIMIG-5
+
+`migrant redo` unapplies then reapplies the latest migration (`--down` then up); `--all`
+redoes all applied migrations. Down-migrations run in reverse application order.
+
+Coverage: `tests/migrant.rs` (kitchen_sink), backend integration tests, unit tests in
+`migrant_lib/src/ops.rs`.

--- a/spec/cli-project-setup.md
+++ b/spec/cli-project-setup.md
@@ -1,0 +1,27 @@
+# CLI Project Setup
+
+init, setup, which-config, and connect-string subcommands for bootstrapping a project.
+
+## CLIPRO-1
+
+`migrant init` creates a `Migrant.toml` config file. Flags: `--type <sqlite|postgres|mysql>`
+selects the database type, `--location <dir>` initializes in a specific directory,
+`--default-from-env` seeds values as `env:VAR_NAME` references, `--no-confirm` disables
+interactive prompts.
+
+## CLIPRO-2
+
+`migrant setup` verifies database credentials and creates the `__migrant_migrations`
+tracking table if it does not exist.
+
+## CLIPRO-3
+
+`migrant which-config` prints the path of the active `Migrant.toml`. The active config is
+found by searching upward from the current directory.
+
+## CLIPRO-4
+
+`migrant connect-string` prints the database connection string, or the database file path
+for SQLite.
+
+Coverage: `tests/migrant.rs` (kitchen_sink) and backend integration tests.

--- a/spec/config-file-and-env-resolution.md
+++ b/spec/config-file-and-env-resolution.md
@@ -1,0 +1,26 @@
+# Config File and Env Resolution
+
+Migrant.toml format, env:VAR value resolution, and automatic .env loading.
+
+## CONFIG-1
+
+`Migrant.toml` keys: `database_type` (sqlite|postgres|mysql), `migration_location`,
+`database_path` (SQLite), `database_name`/`database_user`/`database_password`/
+`database_host`/`database_port` (server databases), `ssl_cert_file` (postgres), and
+`database_params` (key-value connection parameters).
+
+## CONFIG-2
+
+Any config value written as `env:VAR_NAME` resolves from the environment when the config
+is loaded.
+
+## CONFIG-3
+
+A `.env` file is loaded automatically (via dotenvy) before config values are resolved.
+
+## CONFIG-4
+
+A relative `database_path` resolves relative to the config file's directory.
+
+Coverage: unit tests in `migrant_lib/src/config/settings.rs`; `tests/migrant.rs`
+(init --default-from-env).

--- a/spec/database-backends.md
+++ b/spec/database-backends.md
@@ -1,0 +1,29 @@
+# Database Backends
+
+sqlite, postgres, and mysql drivers behind cargo feature flags.
+
+## BACKEND-1
+
+SQLite support (feature `sqlite`, via rusqlite): file-backed and in-memory databases.
+
+## BACKEND-2
+
+PostgreSQL support (feature `postgres`, via the postgres crate), including SSL with an
+optional custom certificate.
+
+## BACKEND-3
+
+MySQL support (feature `mysql`, via the mysql crate).
+
+## BACKEND-4
+
+Connections are established lazily on first use and kept alive per `Config`.
+
+## BACKEND-5
+
+Invoking an operation whose backend feature is disabled returns
+`Error::FeatureRequired` rather than panicking.
+
+Coverage: `migrant_lib/tests/sqlite.rs`; `server_dbs.rs` (postgres/mysql end-to-end,
+gated on POSTGRES_TEST_CONN_STR/MYSQL_TEST_CONN_STR, run via `test.sh` against docker
+databases).

--- a/spec/database-shell.md
+++ b/spec/database-shell.md
@@ -1,0 +1,10 @@
+# Database Shell
+
+shell subcommand opening an interactive REPL to the configured database.
+
+## SHELL-1
+
+`migrant shell` opens the backend's interactive client (`sqlite3`, `psql`, or `mysql`)
+connected to the configured database.
+
+Coverage: unit tests in `migrant_lib/src/ops.rs`.

--- a/spec/distribution.md
+++ b/spec/distribution.md
@@ -1,0 +1,19 @@
+# Distribution
+
+Docker image, cross-platform release binaries, and vendored-openssl static builds.
+
+## DISTRI-1
+
+A pre-built docker image is published as `jaemk/migrant:latest` (built from
+`docker/Dockerfile`).
+
+## DISTRI-2
+
+Release binaries are built for Linux (gnu and musl), macOS (x86_64 and aarch64), and
+Windows via CI workflows.
+
+## DISTRI-3
+
+The `vendored-openssl` cargo feature statically links OpenSSL for portable builds.
+
+Coverage: exercised by CI build workflows, not by repo tests.

--- a/spec/error-handling-api.md
+++ b/spec/error-handling-api.md
@@ -1,0 +1,17 @@
+# Error Handling API
+
+Typed Error variants and helpers.
+
+## ERRORH-1
+
+`Error` variants cover the main failure modes: `MigrationComplete` (nothing left to
+apply/unapply), `MigrationNotFound`, `TagError` (invalid tag format), `FeatureRequired`
+(operation needs a disabled cargo feature), and `Config`.
+
+## ERRORH-2
+
+`Error::is_migration_complete()` identifies the completion case so callers can treat it
+as success; `Migrator::swallow_completion` does this automatically.
+
+Coverage: unit tests in `migrant_lib/src/errors.rs`, `tags.rs`; exercised throughout the
+integration tests.

--- a/spec/in-memory-sqlite.md
+++ b/spec/in-memory-sqlite.md
@@ -1,0 +1,30 @@
+# In-Memory SQLite
+
+Shared in-process :memory: database with live connection access.
+
+## INMEMO-1
+
+`SqliteSettingsBuilder::memory()` (or a `:memory:` database path) configures an in-process
+SQLite database instead of a file.
+
+## INMEMO-2
+
+The in-memory connection is established once and kept alive for the lifetime of the
+`Config`; clones of the `Config` share the same database.
+
+## INMEMO-3
+
+`Config::sqlite_connection()` returns the live `Arc<Mutex<rusqlite::Connection>>` so
+application code can query the same in-memory database the migrations ran against.
+
+## INMEMO-4
+
+`ConnConfig::sqlite_connection()` exposes the same connection inside `FnMigration`
+functions.
+
+## INMEMO-5
+
+`Config::reload()` does not drop the in-memory database.
+
+Coverage: `migrant_lib/tests/sqlite.rs` (in_memory_database_end_to_end,
+in_memory_database_shared_across_clones), `reload_memory.rs`.

--- a/spec/library-config-api.md
+++ b/spec/library-config-api.md
@@ -1,0 +1,33 @@
+# Library Config API
+
+migrant_lib Config: load from Migrant.toml or explicit Settings, setup, reload,
+CLI-compatible tag mode.
+
+## LIBRAR-1
+
+`Config::from_settings_file(path)` loads configuration from a `Migrant.toml` file.
+`search_for_settings_file(dir)` locates one by walking parent directories.
+
+## LIBRAR-2
+
+`Config::with_settings(&settings)` builds a config from an explicit `Settings` value,
+with no config file on disk.
+
+## LIBRAR-3
+
+`Config::setup()` verifies the database connection and creates the migration tracking
+table if missing.
+
+## LIBRAR-4
+
+`Config::reload()` re-reads the settings file (when one is used) and refreshes the applied
+migration list. For in-memory SQLite the live connection is preserved across reloads.
+
+## LIBRAR-5
+
+`Config::use_cli_compatible_tags(bool)` toggles timestamp-prefixed tag validation so
+library-managed migrations interoperate with CLI-created ones; `is_cli_compatible()`
+reports the current mode.
+
+Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`; unit tests in
+`migrant_lib/src/tags.rs`.

--- a/spec/migration-tui.md
+++ b/spec/migration-tui.md
@@ -1,0 +1,26 @@
+# Migration TUI
+
+tui subcommand with interactive migration list and apply controls.
+
+## TUI-1
+
+`migrant tui` launches a terminal UI listing all managed migrations with applied status.
+
+## TUI-2
+
+Navigation: `j`/`k` or Up/Down arrows move the selection.
+
+## TUI-3
+
+Apply controls: `u` applies the next up migration, `d` applies the next down migration,
+`a` applies all up, `D` applies all down.
+
+## TUI-4
+
+`r` refreshes migration status; `q`, Esc, or Ctrl+C exits.
+
+Coverage: unit tests in `src/tui.rs` against an in-memory sqlite config (TUI-1 rendered
+list and applied marks via ratatui's `TestBackend`, TUI-2 navigation and selection
+clamping, TUI-3 all four apply keys plus already-complete messages, TUI-4 refresh and all
+quit keys), and `tests/migrant.rs::tui_requires_an_interactive_terminal` for the non-tty
+guard.

--- a/spec/migration-types.md
+++ b/spec/migration-types.md
@@ -1,0 +1,24 @@
+# Migration Types
+
+FileMigration, EmbeddedMigration, and FnMigration registered via Config::use_migrations.
+
+## MIGTYPE-1
+
+`FileMigration` runs up/down SQL loaded from files at runtime.
+
+## MIGTYPE-2
+
+`EmbeddedMigration` runs up/down SQL from embedded strings (typically `include_str!`),
+so binaries need no migration files on disk.
+
+## MIGTYPE-3
+
+`FnMigration` runs arbitrary Rust functions with signature
+`fn(ConnConfig) -> Result<(), Box<dyn std::error::Error>>` for up and down.
+
+## MIGTYPE-4
+
+`Config::use_migrations(&[...])` registers an explicit, ordered migration list;
+`is_explicit()` reports whether explicit migrations are in use (vs file discovery).
+
+Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`.

--- a/spec/migrator-api.md
+++ b/spec/migrator-api.md
@@ -1,0 +1,26 @@
+# Migrator API
+
+Migrator builder: direction, all, force, fake, show_output, swallow_completion, apply.
+
+## MIGRATOR-1
+
+`Migrator::with_config(&config)` creates a migrator; `apply()` executes pending
+migrations against the live connection.
+
+## MIGRATOR-2
+
+`direction(Direction::Up|Down)` sets the migration direction; `all(bool)` applies every
+remaining migration in that direction instead of just the next one.
+
+## MIGRATOR-3
+
+`force(bool)` continues applying past SQL errors; `fake(bool)` updates the tracking table
+without executing migration SQL.
+
+## MIGRATOR-4
+
+`show_output(bool)` toggles progress output; `swallow_completion(bool)` converts the
+`MigrationComplete` error into `Ok` so "nothing to apply" is not an error.
+
+Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`,
+`tests/migrant.rs`; unit tests in `migrant_lib/src/migrator.rs`.

--- a/spec/self-update.md
+++ b/spec/self-update.md
@@ -1,0 +1,15 @@
+# Self Update
+
+self update subcommand pulling the latest release binary from GitHub.
+
+## SELFUP-1
+
+`migrant self update` replaces the running binary with the latest GitHub release. Requires
+the `update` cargo feature.
+
+## SELFUP-2
+
+Version comparison handles backported releases: an older-versioned release published later
+does not replace a newer installed binary.
+
+Coverage: `update_tests` in `src/main.rs` (backport handling, version comparison).

--- a/spec/settings-builders.md
+++ b/spec/settings-builders.md
@@ -1,0 +1,29 @@
+# Settings Builders
+
+Typed builders for sqlite, postgres, and mysql settings.
+
+## SETTIN-1
+
+`Settings::configure_sqlite()` returns a `SqliteSettingsBuilder` with `database_path`
+(absolute, or relative to the config file), `memory()` for an in-memory database, and
+`migration_location`.
+
+## SETTIN-2
+
+`Settings::configure_postgres()` returns a `PostgresSettingsBuilder` with
+`database_name`/`database_user`/`database_password`/`database_host`/`database_port`,
+`ssl_cert_file` for a custom SSL certificate, and `database_params` for extra connection
+parameters.
+
+## SETTIN-3
+
+`Settings::configure_mysql()` returns a `MySqlSettingsBuilder` with the same
+name/user/password/host/port and `database_params` options.
+
+## SETTIN-4
+
+Generated connection strings percent-encode credentials and parameters so special
+characters in passwords and params are safe.
+
+Coverage: `migrant_lib/tests/server_dbs.rs`, `sqlite.rs`; unit tests in
+`migrant_lib/src/config/builders.rs`. `ssl_cert_file` has no dedicated test.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -201,3 +201,167 @@ impl App {
         frame.render_widget(footer, footer_area);
     }
 }
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use migrant_lib::{EmbeddedMigration, Settings};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn test_app() -> App {
+        let settings = Settings::configure_sqlite().memory().build().unwrap();
+        let mut config = Config::with_settings(&settings);
+        config
+            .use_migrations(&[
+                EmbeddedMigration::with_tag("create-users")
+                    .up("create table users (id integer primary key);")
+                    .down("drop table users;")
+                    .boxed(),
+                EmbeddedMigration::with_tag("create-posts")
+                    .up("create table posts (id integer primary key);")
+                    .down("drop table posts;")
+                    .boxed(),
+            ])
+            .unwrap();
+        config.setup().unwrap();
+        App::new(&config).unwrap()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn applied_count(app: &App) -> usize {
+        app.statuses.iter().filter(|m| m.applied).count()
+    }
+
+    fn buffer_text(app: &mut App) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(60, 16)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push_str(buffer.cell((x, y)).unwrap().symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    // TUI-1
+    #[test]
+    fn lists_migrations_with_applied_status() {
+        let mut app = test_app();
+        assert_eq!(2, app.statuses.len());
+
+        let text = buffer_text(&mut app);
+        assert!(text.contains("migrant"));
+        assert!(text.contains("0/2 applied"));
+        assert!(text.contains("[ ] create-users"));
+        assert!(text.contains("[ ] create-posts"));
+
+        app.handle_key(key(KeyCode::Char('u')));
+        let text = buffer_text(&mut app);
+        assert!(text.contains("1/2 applied"));
+        assert!(text.contains("[✓] create-users"));
+        assert!(text.contains("[ ] create-posts"));
+    }
+
+    // TUI-2
+    #[test]
+    fn navigation_moves_selection() {
+        let mut app = test_app();
+        assert_eq!(Some(0), app.list_state.selected());
+
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(Some(1), app.list_state.selected());
+        // clamped at the last entry
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(Some(1), app.list_state.selected());
+
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(Some(0), app.list_state.selected());
+        // clamped at the first entry
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(Some(0), app.list_state.selected());
+
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(Some(1), app.list_state.selected());
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(Some(0), app.list_state.selected());
+    }
+
+    // TUI-3
+    #[test]
+    fn apply_keys_run_migrations() {
+        let mut app = test_app();
+        assert_eq!(0, applied_count(&app));
+
+        // `d` with nothing applied reports there's nothing to do
+        app.handle_key(key(KeyCode::Char('d')));
+        assert_eq!("Nothing to un-apply", app.message);
+
+        // `u` applies one up migration at a time
+        app.handle_key(key(KeyCode::Char('u')));
+        assert_eq!(1, applied_count(&app));
+        assert_eq!("Applied [up] migration", app.message);
+        app.handle_key(key(KeyCode::Char('u')));
+        assert_eq!(2, applied_count(&app));
+
+        // `u` with everything applied reports completion
+        app.handle_key(key(KeyCode::Char('u')));
+        assert_eq!(2, applied_count(&app));
+        assert_eq!("No un-applied migrations", app.message);
+
+        // `D` un-applies everything
+        app.handle_key(key(KeyCode::Char('D')));
+        assert_eq!(0, applied_count(&app));
+        assert_eq!("Applied all [down] migrations", app.message);
+
+        // `a` applies everything
+        app.handle_key(key(KeyCode::Char('a')));
+        assert_eq!(2, applied_count(&app));
+        assert_eq!("Applied all [up] migrations", app.message);
+
+        // `d` un-applies one down migration
+        app.handle_key(key(KeyCode::Char('d')));
+        assert_eq!(1, applied_count(&app));
+        assert_eq!("Applied [down] migration", app.message);
+    }
+
+    // TUI-4
+    #[test]
+    fn refresh_picks_up_external_changes() {
+        let mut app = test_app();
+        assert_eq!(0, applied_count(&app));
+
+        // apply a migration outside the app; config clones share the
+        // same in-memory database
+        Migrator::with_config(&app.config)
+            .show_output(false)
+            .apply()
+            .unwrap();
+        assert_eq!(0, applied_count(&app));
+
+        app.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(1, applied_count(&app));
+        assert_eq!("Refreshed", app.message);
+    }
+
+    // TUI-4
+    #[test]
+    fn quit_keys() {
+        for quit_key in [
+            key(KeyCode::Char('q')),
+            key(KeyCode::Esc),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        ] {
+            let mut app = test_app();
+            assert!(!app.quit);
+            app.handle_key(quit_key);
+            assert!(app.quit);
+        }
+    }
+}

--- a/tests/bash_completions.rs
+++ b/tests/bash_completions.rs
@@ -1,0 +1,62 @@
+//! `self bash-completions` integration tests
+//!
+//! These run the compiled `migrant` binary but touch no database or
+//! project config, so they only need the `integration_tests` feature:
+//!
+//! ```text
+//! cargo test --features integration_tests
+//! ```
+#![cfg(feature = "integration_tests")]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn migrant() -> Command {
+    Command::cargo_bin("migrant").expect("binary built")
+}
+
+// BASHCO-1
+#[test]
+fn bash_completions_write_to_stdout() {
+    migrant()
+        .args(["self", "bash-completions"])
+        .assert()
+        .success()
+        .stdout(contains("_migrant()"))
+        .stdout(contains("complete -F _migrant"));
+}
+
+// BASHCO-2
+#[test]
+fn bash_completions_install_writes_to_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("migrant-completions.bash");
+
+    migrant()
+        .args(["self", "bash-completions", "install", "--path"])
+        .arg(&path)
+        .write_stdin("y\n")
+        .assert()
+        .success()
+        .stdout(contains("Completion file will be installed at:"));
+
+    let script = std::fs::read_to_string(&path).unwrap();
+    assert!(script.contains("complete -F _migrant"));
+}
+
+// BASHCO-2
+#[test]
+fn bash_completions_install_declined_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("migrant-completions.bash");
+
+    migrant()
+        .args(["self", "bash-completions", "install", "--path"])
+        .arg(&path)
+        .write_stdin("n\n")
+        .assert()
+        .failure()
+        .stderr(contains("Unable to confirm"));
+
+    assert!(!path.exists());
+}

--- a/tests/migrant.rs
+++ b/tests/migrant.rs
@@ -89,3 +89,14 @@ fn kitchen_sink() {
 
     let _ = migrant().args(["apply", "-ad"]).assert();
 }
+
+// TUI-1: with stdout piped (not a terminal) the tui refuses to start,
+// before touching the database
+#[test]
+fn tui_requires_an_interactive_terminal() {
+    migrant()
+        .arg("tui")
+        .assert()
+        .failure()
+        .stderr(contains("requires an interactive terminal"));
+}


### PR DESCRIPTION
- Add spec/ with a feature status table and per-feature docs with stable IDs
- Add tests/bash_completions.rs: `self bash-completions` stdout output and install to a path, including declined confirmation
- Add unit tests in src/tui.rs against an in-memory sqlite config: list rendering, navigation, apply keys, refresh, quit keys
- Add a tests/migrant.rs case: `tui` refuses to start when stdout is not a terminal