### PR TITLE
synchronize migration runs with an advisory lock, apply migrations transactionally

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: docs
+
+# Pages source is set to GitHub Actions for this repo. Builds the mdBook and
+# deploys it on docs changes. `workflow_dispatch` allows a manual run.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  MDBOOK_VERSION: '0.5.3'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          url="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: mdbook build docs
+      - name: Assemble site
+        # Landing page at the root, mdBook docs under /guide/.
+        run: |
+          mkdir -p _site
+          cp -r docs/landing/. _site/
+          mkdir -p _site/guide
+          cp -r docs/book/. _site/guide/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
+    steps:
+      # Pages intermittently returns "Deployment failed, try again later" on the
+      # first status poll. Retry once after a short settle so a transient backend
+      # blip does not fail the run; a persistent failure still fails the retry.
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+      - if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+      - id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ db
 db.db
 migrant.db
 .idea
+/docs/book
+/local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@
   A server connection is recovered in place on error rather than dropped, so the lock is held
   for the whole run, including a `force`d run continuing past a failed migration
 - `EmbeddedMigration::no_transaction` / `FileMigration::no_transaction` and
-  `Migratable::use_transaction` to opt a migration out of transaction wrapping
+  `Migratable::use_transaction(direction)` to opt a migration out of transaction
+  wrapping, resolved per direction
+- `-- migrant:no-transaction` SQL directive to opt a single direction out from
+  the migration file itself (works for `migrant` CLI file migrations); a
+  directive in the SQL takes precedence over the builder flag
 
 ### Changed
 - Update `migrant_lib` to 0.35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@
 - GitHub Actions CI and release workflows. Releases are triggered by tags:
   `lib-v*` publishes `migrant_lib`, `cli-v*` publishes `migrant` and builds release binaries
 - `vendored-openssl` feature for static (musl) builds
+- `Migrator::synchronized` (default on): serialize migration runs across processes with a
+  database advisory lock (postgres `pg_advisory_lock`, mysql `GET_LOCK`); no-op on sqlite.
+  A server connection is recovered in place on error rather than dropped, so the lock is held
+  for the whole run, including a `force`d run continuing past a failed migration
+- `EmbeddedMigration::no_transaction` / `FileMigration::no_transaction` and
+  `Migratable::use_transaction` to opt a migration out of transaction wrapping
 
 ### Changed
 - Update `migrant_lib` to 0.35
+- Each migration's SQL and its `__migrant_migrations` bookkeeping row are now applied in a
+  single transaction by default, so a failed migration leaves no partial state or record.
+  Migration SQL should no longer include its own `begin`/`commit`
 - Port CLI from clap 2 to clap 4, preserving the existing interface
 - `self update` now resolves `cli-v*` release tags
 - Replace `dotenv` with `dotenvy`, `error-chain` with plain error types

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help docs docs-build test
+
+help:
+	@echo "targets:"
+	@echo "  docs       build the docs site and serve it locally with live reload"
+	@echo "  docs-build build the docs site to docs/book"
+	@echo "  test       run the library test suite against throwaway docker databases"
+
+# Serve the mdBook docs (docs/) locally with live reload, opening a browser.
+# Same tool the Pages workflow uses; install with `cargo install mdbook` (or grab
+# a release from https://github.com/rust-lang/mdBook/releases).
+docs:
+	@command -v mdbook >/dev/null || { echo "error: mdbook not found; install with 'cargo install mdbook'"; exit 1; }
+	mdbook serve docs --open
+
+# Build the static site to docs/book (what CI deploys to Pages).
+docs-build:
+	@command -v mdbook >/dev/null || { echo "error: mdbook not found; install with 'cargo install mdbook'"; exit 1; }
+	mdbook build docs
+
+# Run the migrant_lib suite against throwaway docker postgres/mysql.
+test:
+	bash migrant_lib/test.sh

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ If the `migration_location` directory doesn't exist, it will be created the firs
 For example, `database_user = "env:DB_USER"` will use the value of the environment variable `DB_USER`.
 If a `.env` file exists, it will be "sourced" automatically before your `Migrant.toml` is loaded.
 
-*Note:* SQL statements are batch executed as is. If you want your migration to happen atomically in a
-transaction you must manually wrap your statements in a transaction (`begin transaction; ... commit;`).
+*Note:* Each migration and its `__migrant_migrations` bookkeeping row are applied in a single transaction
+by default, so do not wrap your SQL in your own `begin`/`commit`. For DDL a backend cannot run in a
+transaction (e.g. postgres `create index concurrently` or `alter type ... add value`), opt a direction out
+with a `-- migrant:no-transaction` comment line in that migration file. See the
+[docs](https://jaemk.github.io/migrant/).
 
 
 ### Installation

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1,0 +1,135 @@
+/* migrant docs -- retint of the mdBook navy theme to match the landing page:
+   deep teal-green ground, iridescent-green + light-sky-blue accents (the
+   hummingbird's colors). Loaded via `additional-css`. */
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+
+:root {
+  --green: #1db47c;
+  --blue: #5cc7f5;
+  --cream: #eafff6;
+  --sidebar-width: 290px;
+  --content-max-width: 760px;
+}
+
+/* Retint the navy theme (default + preferred dark) to teal-green-black. */
+.navy {
+  --bg: #05140f;
+  --fg: #d7f5ea;
+
+  --sidebar-bg: #04110d;
+  --sidebar-fg: #9ec9bd;
+  --sidebar-non-existant: #3a5b52;
+  --sidebar-active: #6ff0c2;
+  --sidebar-spacer: #0d2a24;
+
+  --scrollbar: #1f5347;
+
+  --icons: #6f9c90;
+  --icons-hover: #b6fde6;
+
+  --links: #57e0c2;
+
+  --inline-code-color: #6cd6f5;
+
+  --theme-popup-bg: #07191466;
+  --theme-popup-border: #163b34;
+  --theme-hover: #0f2e28;
+
+  --quote-bg: #0a201b;
+  --quote-border: #14524a;
+
+  --table-border-color: #143b34;
+  --table-header-bg: #0e2f2a;
+  --table-alternate-bg: #08201b;
+
+  --searchbar-border-color: #1a4a42;
+  --searchbar-bg: #071914;
+  --searchbar-fg: #d7f5ea;
+  --searchbar-shadow-color: #02322a;
+  --searchresults-header-fg: #6cae9d;
+  --searchresults-border-color: #143b34;
+  --searchresults-li-bg: #0a221c;
+  --search-mark-bg: #2f7d68;
+}
+
+/* Page background: green/blue glow behind the dark ground. */
+html.navy,
+.navy body {
+  background:
+    radial-gradient(1100px 620px at 80% -8%, #0b2e24 0%, transparent 58%),
+    radial-gradient(820px 540px at 4% 2%, #072a30 0%, transparent 52%),
+    var(--bg);
+}
+
+/* Typography */
+.navy .content {
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+.navy .content h1,
+.navy .content h2,
+.navy .content h3 {
+  font-weight: 700;
+  letter-spacing: -0.4px;
+}
+.navy .content h1 {
+  background: linear-gradient(120deg, #eafff6 20%, var(--green) 60%, var(--blue) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  /* the gradient only paints the padding box, so leave room for descenders */
+  padding-bottom: 0.12em;
+}
+.navy .content h2 {
+  border-bottom: 1px solid var(--quote-border);
+  padding-bottom: 0.3em;
+}
+
+/* Links: glow on hover. */
+.navy .content a { text-decoration: none; border-bottom: 1px solid transparent; transition: border-color 0.15s, color 0.15s; }
+.navy .content a:hover { color: #8af0d3; border-bottom-color: rgba(87, 224, 194, 0.55); }
+
+/* Code: monospace + soft panel. */
+.navy code { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; }
+.navy .content pre {
+  border: 1px solid var(--quote-border);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+.navy .content pre > .buttons button { color: var(--icons); }
+
+/* Tables: readable borders on the dark ground. */
+.navy .content table td,
+.navy .content table th { border: 1px solid var(--table-border-color); }
+
+/* Sidebar: active chapter gets a green spine. */
+.navy .chapter li.chapter-item a { border-radius: 7px; transition: background 0.15s, color 0.15s; padding-left: 8px; }
+.navy .chapter li.chapter-item a:hover { background: var(--theme-hover); color: var(--cream); }
+.navy .chapter li.chapter-item a.active {
+  background: linear-gradient(90deg, rgba(29, 180, 124, 0.16), transparent);
+  border-left: 3px solid var(--green);
+  color: #aef7dc;
+}
+.navy .sidebar .sidebar-title { color: #6cae9d; }
+
+/* Top bar: a hairline glow under the menu. */
+.navy .menu-bar { border-bottom: 1px solid var(--quote-border); backdrop-filter: blur(6px); }
+
+/* Blockquotes as glowing callouts. */
+.navy blockquote {
+  border-left: 3px solid var(--green);
+  border-radius: 0 10px 10px 0;
+}
+
+/* "Back to migrant" link injected into the sidebar by custom.js. */
+.migrant-home {
+  display: block;
+  margin: 0 14px 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--quote-border);
+  border-radius: 9px;
+  font-weight: 600;
+  color: #aef7dc !important;
+  background: linear-gradient(120deg, rgba(29, 180, 124, 0.14), rgba(92, 199, 245, 0.12));
+}
+.migrant-home:hover { border-color: rgba(92, 199, 245, 0.5); }

--- a/docs/assets/custom.js
+++ b/docs/assets/custom.js
@@ -1,0 +1,18 @@
+// Inject a "back to the migrant landing page" link at the top of the sidebar.
+// The landing page lives one level up from the book (site root vs /guide/).
+(function () {
+  function addHomeLink() {
+    var scroll = document.querySelector(".sidebar .sidebar-scrollbox");
+    if (!scroll || scroll.querySelector(".migrant-home")) return;
+    var a = document.createElement("a");
+    a.className = "migrant-home";
+    a.href = "../";
+    a.textContent = "← migrant home";
+    scroll.insertBefore(a, scroll.firstChild);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", addHomeLink);
+  } else {
+    addHomeLink();
+  }
+})();

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,20 @@
+[book]
+title = "migrant"
+description = "Embeddable database migration management for SQLite, PostgreSQL, and MySQL, with a companion CLI."
+authors = ["James Kominick"]
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/jaemk/migrant"
+edit-url-template = "https://github.com/jaemk/migrant/edit/main/docs/{path}"
+# Docs are served under /guide/ on the Pages site; the landing page owns the root.
+site-url = "/migrant/guide/"
+additional-css = ["assets/custom.css"]
+additional-js = ["assets/custom.js"]
+
+[output.html.fold]
+enable = true
+level = 1

--- a/docs/landing/app.js
+++ b/docs/landing/app.js
@@ -1,0 +1,70 @@
+// Progressive enhancement for the landing page. Nothing here is required for
+// the page to render or for the links to work.
+
+// Copy-to-clipboard on the command snippets.
+document.querySelectorAll(".copy").forEach((btn) => {
+  if (btn.tagName === "A") return; // the releases "Open" link is a real link
+  btn.addEventListener("click", async () => {
+    const text = btn.getAttribute("data-copy") || "";
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard API blocked (e.g. file://). Fall back to a hidden textarea.
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); } catch { /* give up quietly */ }
+      ta.remove();
+    }
+    const original = btn.textContent;
+    btn.textContent = "Copied";
+    btn.classList.add("copied");
+    setTimeout(() => {
+      btn.textContent = original;
+      btn.classList.remove("copied");
+    }, 1400);
+  });
+});
+
+// Install-method tabs: toggle the active tab and show its panel.
+document.querySelectorAll(".install").forEach((box) => {
+  const tabs = box.querySelectorAll(".tab");
+  const panels = box.querySelectorAll(".panel");
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const which = tab.getAttribute("data-tab");
+      tabs.forEach((t) => {
+        const on = t === tab;
+        t.classList.toggle("is-active", on);
+        t.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      panels.forEach((p) => {
+        const on = p.getAttribute("data-panel") === which;
+        p.classList.toggle("is-active", on);
+        p.hidden = !on;
+      });
+    });
+  });
+});
+
+// Subtle pointer parallax on the hero art. Skipped when the user prefers reduced
+// motion or on coarse (touch) pointers.
+const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const coarse = window.matchMedia("(pointer: coarse)").matches;
+const art = document.querySelector(".bird");
+const stage = document.getElementById("stage");
+if (art && stage && !reduce && !coarse) {
+  let raf = 0;
+  window.addEventListener("pointermove", (e) => {
+    const dx = (e.clientX / window.innerWidth - 0.5) * 2;
+    const dy = (e.clientY / window.innerHeight - 0.5) * 2;
+    if (raf) return;
+    raf = requestAnimationFrame(() => {
+      art.style.transform = `translate(${dx * 12}px, ${dy * 10}px) rotate(${dx * 0.8}deg)`;
+      raf = 0;
+    });
+  });
+}

--- a/docs/landing/favicon.svg
+++ b/docs/landing/favicon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="g" gradientUnits="userSpaceOnUse" cx="38" cy="18" r="38">
+      <stop offset="0%" stop-color="#5fe0a8"/>
+      <stop offset="45%" stop-color="#1fae76"/>
+      <stop offset="100%" stop-color="#0a5a41"/>
+    </radialGradient>
+    <linearGradient id="b" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6fdf7"/>
+      <stop offset="100%" stop-color="#cfe9da"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#07231c"/>
+  <!-- head -->
+  <circle cx="40" cy="29" r="19" fill="url(#g)"/>
+  <!-- white chin/throat (female: no ruby) -->
+  <ellipse cx="30" cy="41" rx="7.5" ry="6" transform="rotate(25 30 41)" fill="url(#b)"/>
+  <!-- long needle bill -->
+  <path d="M26,31 L2,49 L27,37 Z" fill="#22322c"/>
+  <!-- blush -->
+  <ellipse cx="37" cy="36" rx="3.6" ry="2.6" transform="rotate(20 37 36)" fill="#f2a0b5" opacity="0.75"/>
+  <!-- eye -->
+  <circle cx="36" cy="27" r="5.2" fill="#0e1f19"/>
+  <circle cx="37.8" cy="25.2" r="1.9" fill="#ffffff"/>
+  <!-- crown sheen -->
+  <ellipse cx="37" cy="16" rx="9" ry="4" transform="rotate(-14 37 16)" fill="#ffffff" opacity="0.35"/>
+</svg>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>migrant -- database migration management</title>
+  <meta name="description" content="migrant manages up/down SQL migrations for SQLite, PostgreSQL, and MySQL, from a CLI or embedded in your Rust application." />
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="bg" aria-hidden="true">
+    <span class="orb orb-a"></span>
+    <span class="orb orb-b"></span>
+    <span class="orb orb-c"></span>
+    <span class="grain"></span>
+  </div>
+
+  <header class="nav">
+    <a class="brand" href="#top">
+      <img class="brand-mark" src="favicon.svg" alt="" width="24" height="24" />
+      <span class="brand-name">migrant</span>
+    </a>
+    <nav class="nav-links">
+      <a href="guide/">Docs</a>
+      <a href="guide/quickstart.html">Quickstart</a>
+      <a href="https://github.com/jaemk/migrant">GitHub</a>
+    </nav>
+  </header>
+
+  <main id="top" class="hero">
+    <div class="hero-stage" id="stage">
+      <!-- A female ruby-throated hummingbird (green, no ruby throat), hovering
+           with a little sky-blue backpack full of database migrations. -->
+      <svg class="bird" viewBox="0 0 600 640" role="img"
+           aria-label="A cute green female hummingbird hovering with a little backpack full of database migrations">
+        <defs>
+          <!-- one shared user-space gradient so head, neck, and body blend seamlessly -->
+          <radialGradient id="birdGreen" gradientUnits="userSpaceOnUse" cx="235" cy="200" r="340">
+            <stop offset="0%" stop-color="#5fe0a8" />
+            <stop offset="30%" stop-color="#1fae76" />
+            <stop offset="65%" stop-color="#0e6b4d" />
+            <stop offset="100%" stop-color="#083f2e" />
+          </radialGradient>
+          <linearGradient id="belly" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#f6fdf7" />
+            <stop offset="100%" stop-color="#cfe9da" />
+          </linearGradient>
+          <linearGradient id="wingGrad" x1="0" y1="1" x2="1" y2="0">
+            <stop offset="0%" stop-color="#2fa98c" />
+            <stop offset="55%" stop-color="#5eccae" />
+            <stop offset="100%" stop-color="#9fe4ff" />
+          </linearGradient>
+          <linearGradient id="packBlue" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#8fdcff" />
+            <stop offset="100%" stop-color="#38a9e6" />
+          </linearGradient>
+          <radialGradient id="sheen" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
+            <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+          </radialGradient>
+          <filter id="softGlow" x="-60%" y="-60%" width="220%" height="220%">
+            <feGaussianBlur stdDeviation="14" />
+          </filter>
+          <filter id="wingBlur" x="-40%" y="-40%" width="180%" height="180%">
+            <feGaussianBlur stdDeviation="4" />
+          </filter>
+        </defs>
+
+        <!-- soft glow halo behind the bird -->
+        <ellipse cx="310" cy="330" rx="190" ry="160" fill="#12b981" opacity="0.14" filter="url(#softGlow)" />
+
+        <g class="bird-body">
+          <!-- body frame: origin at body center, x-axis runs head->tail (down-right) -->
+          <g transform="translate(335 330) rotate(38)">
+            <!-- ghost wing (upstroke), blurred, to imply fast beats -->
+            <g class="wing-ghost" filter="url(#wingBlur)" opacity="0.35">
+              <path fill="url(#wingGrad)"
+                    d="M20,-40 C 45,-100 75,-150 125,-170 C 112,-118 100,-75 88,-32 C 62,-26 38,-30 20,-40 Z"
+                    transform="rotate(-26 20 -40)" />
+            </g>
+
+            <!-- fanned tail with white tips (female ruby-throat) -->
+            <g class="tail-fan">
+              <g fill="#0c5341" stroke="#083b2e" stroke-width="1.5">
+                <path d="M80,-4 C 130,-14 165,-12 185,-2 C 165,8 130,10 82,8 Z" />
+                <path d="M80,4 C 125,8 158,20 172,38 C 150,42 118,34 78,14 Z" />
+                <path d="M76,10 C 110,26 130,46 136,66 C 116,62 96,44 72,18 Z" />
+              </g>
+              <g fill="#eafff6">
+                <ellipse cx="181" cy="-2" rx="7" ry="4.5" />
+                <ellipse cx="168" cy="37" rx="6.5" ry="4.5" />
+                <ellipse cx="133" cy="62" rx="6" ry="4.5" />
+              </g>
+            </g>
+
+            <!-- body -->
+            <ellipse cx="0" cy="0" rx="95" ry="60" fill="url(#birdGreen)" />
+            <!-- white underside -->
+            <ellipse cx="-14" cy="26" rx="76" ry="36" fill="url(#belly)" />
+
+            <!-- backpack full of migrations, sitting on her back -->
+            <g>
+              <!-- shoulder strap -->
+              <rect x="-62" y="-58" width="13" height="66" rx="6" fill="#0b4a3c" />
+              <!-- pack body -->
+              <rect x="-45" y="-102" width="86" height="74" rx="17"
+                    fill="url(#packBlue)" stroke="#e6f9ff" stroke-opacity="0.4" stroke-width="2.5" />
+              <!-- front pocket + buckle -->
+              <rect x="-30" y="-56" width="54" height="24" rx="9" fill="#2f8fd0" />
+              <circle cx="-3" cy="-44" r="4" fill="#e6f9ff" />
+              <!-- migrations poking out the top: little database cylinders -->
+              <g stroke="#063f31" stroke-opacity="0.35" stroke-width="1">
+                <g>
+                  <ellipse cx="-25" cy="-106" rx="10" ry="3.5" fill="#7fe8c0" />
+                  <path d="M-35,-106 v12 a10,3.5 0 0 0 20,0 v-12" fill="#2bbd84" />
+                </g>
+                <g>
+                  <ellipse cx="0" cy="-112" rx="10" ry="3.5" fill="#fbfffc" />
+                  <path d="M-10,-112 v18 a10,3.5 0 0 0 20,0 v-18" fill="#d9efe2" />
+                </g>
+                <g>
+                  <ellipse cx="25" cy="-106" rx="10" ry="3.5" fill="#7fe8c0" />
+                  <path d="M15,-106 v12 a10,3.5 0 0 0 20,0 v-12" fill="#2bbd84" />
+                </g>
+              </g>
+              <circle class="mig-glint" cx="-3" cy="-116" r="2.6" fill="#ffffff" />
+            </g>
+
+            <!-- near wing: slim pointed hummingbird blade, swept back -->
+            <g class="wing-near">
+              <path fill="url(#wingGrad)" fill-opacity="0.9"
+                    stroke="#d6fff2" stroke-opacity="0.35" stroke-width="1.5"
+                    d="M20,-40 C 45,-100 75,-150 125,-170 C 112,-118 100,-75 88,-32 C 62,-26 38,-30 20,-40 Z" />
+            </g>
+          </g>
+
+          <!-- neck bridge so the head flows into the body -->
+          <circle cx="288" cy="282" r="52" fill="url(#birdGreen)" />
+
+          <!-- head -->
+          <circle cx="250" cy="238" r="64" fill="url(#birdGreen)" />
+          <!-- white chin/throat (female: no ruby), one smooth sweep into the belly -->
+          <path fill="url(#belly)"
+                d="M203,260
+                   C 190,290 202,320 236,334
+                   C 268,346 296,336 302,318
+                   C 306,302 292,290 272,284
+                   C 246,276 218,266 203,260 Z" />
+          <!-- long needle bill, slightly down-turned -->
+          <path d="M196,244 L62,284 L202,264 Z" fill="#22322c" />
+          <!-- rosy cheek blush -->
+          <ellipse cx="252" cy="262" rx="11" ry="8" transform="rotate(22 252 262)" fill="#f2a0b5" opacity="0.75" />
+          <!-- big cute eye -->
+          <circle cx="238" cy="236" r="14" fill="#0e1f19" />
+          <circle class="eye-glint" cx="243" cy="231" r="4.6" fill="#ffffff" />
+          <circle cx="233" cy="241" r="2" fill="#ffffff" opacity="0.8" />
+          <!-- crown sheen -->
+          <ellipse cx="235" cy="196" rx="34" ry="14" transform="rotate(-18 235 196)" fill="url(#sheen)" opacity="0.65" />
+        </g>
+      </svg>
+    </div>
+
+    <div class="hero-copy">
+      <h1 class="title">migrant</h1>
+      <p class="tagline">
+        <strong>up</strong>/<strong>down</strong> SQL migrations for SQLite,
+        PostgreSQL, and MySQL. Each migration is <strong>atomic</strong> and
+        concurrent runs <strong>serialize</strong> behind an advisory lock. Use
+        the CLI, or embed it in your Rust app.
+      </p>
+
+      <div class="cmds">
+        <div class="then"><span><a href="guide/install.html">install</a></span></div>
+
+        <div class="install" id="install">
+          <div class="tabs" role="tablist" aria-label="Install method">
+            <button class="tab is-active" type="button" role="tab" aria-selected="true" data-tab="cargo">cargo</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" data-tab="releases">releases</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" data-tab="docker">docker</button>
+          </div>
+
+          <div class="panel is-active" role="tabpanel" data-panel="cargo">
+            <div class="cmd">
+              <code><span class="prompt">$</span> cargo install migrant --features 'postgres sqlite mysql update'</code>
+              <button class="copy" type="button" aria-label="Copy cargo install command" data-copy="cargo install migrant --features 'postgres sqlite mysql update'">Copy</button>
+            </div>
+          </div>
+
+          <div class="panel" role="tabpanel" data-panel="releases" hidden>
+            <div class="cmd">
+              <code><span class="prompt">&#8599;</span> github.com/jaemk/migrant/releases</code>
+              <a class="copy copy-link" href="https://github.com/jaemk/migrant/releases" target="_blank" rel="noopener">Open</a>
+            </div>
+          </div>
+
+          <div class="panel" role="tabpanel" data-panel="docker" hidden>
+            <div class="cmd">
+              <code><span class="prompt">$</span> docker run --rm jaemk/migrant:latest migrant --help</code>
+              <button class="copy" type="button" aria-label="Copy docker run command" data-copy="docker run --rm jaemk/migrant:latest migrant --help">Copy</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="then"><span><a href="guide/quickstart.html">init</a></span></div>
+
+        <div class="cmd" id="init">
+          <code><span class="prompt">$</span> migrant init --type postgres</code>
+          <button class="copy" type="button" aria-label="Copy init command" data-copy="migrant init --type postgres">Copy</button>
+        </div>
+
+        <div class="then"><span><a href="guide/migrations.html">new</a></span></div>
+
+        <div class="cmd" id="new">
+          <code><span class="prompt">$</span> migrant new create-users</code>
+          <button class="copy" type="button" aria-label="Copy new command" data-copy="migrant new create-users">Copy</button>
+        </div>
+
+        <div class="then"><span>apply</span></div>
+
+        <div class="cmd" id="apply">
+          <code><span class="prompt">$</span> migrant apply --all</code>
+          <button class="copy" type="button" aria-label="Copy apply command" data-copy="migrant apply --all">Copy</button>
+        </div>
+      </div>
+
+      <div class="cta">
+        <a class="btn btn-primary" href="guide/">Read the docs</a>
+        <a class="btn btn-ghost" href="guide/quickstart.html">Quickstart</a>
+        <a class="btn btn-ghost" href="https://github.com/jaemk/migrant">
+          <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <section class="features">
+    <article class="card">
+      <h3>Track</h3>
+      <p>Plain <code>up.sql</code>/<code>down.sql</code> files under version
+         control, applied in order and recorded in a
+         <code>__migrant_migrations</code> table. SQLite, PostgreSQL, and MySQL,
+         from the CLI or embedded in your Rust app.</p>
+    </article>
+    <article class="card">
+      <h3>Atomic</h3>
+      <p>Each migration and its bookkeeping row commit or roll back in one
+         transaction, so a failure leaves no partial state. Opt a direction out
+         with <code>-- migrant:no-transaction</code> for DDL a backend cannot run
+         in a transaction.</p>
+    </article>
+    <article class="card">
+      <h3>Safe under concurrency</h3>
+      <p>Runs against a server database take a session advisory lock, so several
+         app instances applying migrations on boot serialize instead of racing.
+         Held across a <code>--force</code> run, released if the process dies.</p>
+    </article>
+  </section>
+
+  <footer class="foot">
+    <span>migrant &middot; embeddable migration management</span>
+    <a href="https://github.com/jaemk/migrant/tree/main/spec">Spec</a>
+  </footer>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/docs/landing/styles.css
+++ b/docs/landing/styles.css
@@ -1,0 +1,271 @@
+/* migrant landing page -- palette drawn from the hummingbird hero:
+   iridescent green + light sky blue on a deep teal-green ground. */
+
+:root {
+  --ink: #05140f;
+  --ink-2: #082019;
+  --panel: rgba(12, 40, 33, 0.55);
+  --panel-line: rgba(45, 190, 140, 0.2);
+  --text: #d7f5ea;
+  --muted: #8fbdb0;
+  --green: #1db47c;       /* iridescent back/crown (female ruby-throat: darker) */
+  --green-deep: #0e8a63;
+  --blue: #5cc7f5;        /* light sky blue */
+  --cream: #eafff6;       /* pale throat/belly */
+  --glow: 0 0 40px rgba(29, 180, 124, 0.35);
+  --radius: 16px;
+  --maxw: 1080px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 700px at 72% -10%, #0b2e24 0%, transparent 60%),
+    radial-gradient(900px 600px at 8% 8%, #072a30 0%, transparent 55%),
+    var(--ink);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ---- animated background ---- */
+.bg { position: fixed; inset: 0; z-index: 0; pointer-events: none; overflow: hidden; }
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.5;
+  mix-blend-mode: screen;
+  animation: drift 22s ease-in-out infinite;
+}
+.orb-a { width: 460px; height: 460px; left: -80px; top: 6%;
+  background: radial-gradient(circle, #18a873, transparent 65%); }
+.orb-b { width: 540px; height: 540px; right: -120px; top: 22%;
+  background: radial-gradient(circle, #4fb8ec, transparent 65%);
+  animation-delay: -7s; }
+.orb-c { width: 380px; height: 380px; left: 36%; bottom: -120px;
+  background: radial-gradient(circle, #1cb389, transparent 65%);
+  animation-delay: -13s; }
+.grain {
+  position: absolute; inset: 0;
+  background-image: radial-gradient(rgba(120, 230, 190, 0.10) 1px, transparent 1px);
+  background-size: 26px 26px;
+  mask-image: radial-gradient(70% 60% at 50% 30%, #000 40%, transparent 100%);
+  -webkit-mask-image: radial-gradient(70% 60% at 50% 30%, #000 40%, transparent 100%);
+}
+@keyframes drift {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(40px, -30px) scale(1.08); }
+  66% { transform: translate(-30px, 24px) scale(0.96); }
+}
+
+/* ---- nav ---- */
+.nav {
+  position: relative; z-index: 3;
+  max-width: var(--maxw); margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 22px 24px;
+}
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 800; font-size: 20px; }
+.brand-mark {
+  width: 24px; height: 24px; border-radius: 7px;
+  box-shadow: 0 0 18px rgba(29, 180, 124, 0.45);
+}
+.brand-name { letter-spacing: 0.3px; }
+.nav-links { display: flex; gap: 22px; font-weight: 500; color: var(--muted); }
+.nav-links a { transition: color 0.2s; }
+.nav-links a:hover { color: var(--text); }
+
+/* ---- hero ---- */
+.hero {
+  position: relative; z-index: 2;
+  max-width: var(--maxw); margin: 0 auto;
+  padding: 18px 24px 40px;
+  display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: 24px; align-items: center;
+  min-height: 72vh;
+}
+.hero-stage { display: flex; justify-content: center; align-items: center; }
+.bird { width: min(100%, 500px); height: auto; overflow: visible; will-change: transform; }
+
+.hero-copy { max-width: 520px; min-width: 0; }
+.title {
+  font-size: clamp(56px, 9vw, 104px); line-height: 1; margin: 0 0 10px;
+  /* the gradient only paints the padding box, so leave room for the g descender */
+  padding-bottom: 0.12em;
+  font-weight: 800; letter-spacing: -2px;
+  background: linear-gradient(120deg, #eafff6 10%, var(--green) 55%, var(--blue) 100%);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.tagline { font-size: 19px; line-height: 1.55; color: var(--muted); margin: 0 0 26px; }
+.tagline strong { color: var(--text); font-weight: 600; }
+
+.cmds { margin-bottom: 26px; }
+.cmd {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  background: var(--panel); border: 1px solid var(--panel-line);
+  border-radius: 12px; padding: 12px 12px 12px 16px;
+  backdrop-filter: blur(8px); margin-bottom: 26px;
+}
+.cmds .cmd { margin-bottom: 0; }
+
+/* ---- install box with method tabs ---- */
+.install { margin-bottom: 0; }
+.tabs { display: flex; gap: 6px; margin-bottom: 10px; flex-wrap: wrap; }
+.tab {
+  cursor: pointer; font-family: inherit;
+  border: 1px solid var(--panel-line);
+  background: var(--panel); color: var(--muted);
+  border-radius: 9px; padding: 7px 16px; font-size: 13px; font-weight: 600;
+  backdrop-filter: blur(8px);
+  transition: background 0.2s, color 0.2s, border-color 0.2s, transform 0.1s;
+}
+.tab:hover { color: var(--text); }
+.tab:active { transform: scale(0.97); }
+.tab.is-active {
+  color: #04231b; border-color: transparent;
+  background: linear-gradient(120deg, var(--green), var(--blue));
+  box-shadow: var(--glow);
+}
+.panel { display: none; }
+.panel.is-active { display: block; }
+/* Multi-line install snippets render their newlines and scroll if too wide. */
+.cmd-multiline { align-items: flex-start; }
+.cmd-multiline code { white-space: pre; line-height: 1.7; }
+/* The releases tab's "Open" is a link styled like the Copy button. */
+.copy-link { display: inline-flex; align-items: center; }
+
+/* divider label between steps */
+.then {
+  display: flex; align-items: center; gap: 12px;
+  margin: 12px 2px; color: var(--muted);
+  font-size: 12px; letter-spacing: 0.5px; text-transform: uppercase;
+}
+.then::before, .then::after {
+  content: ""; height: 1px; flex: 1;
+  background: linear-gradient(90deg, transparent, var(--panel-line), transparent);
+}
+.then a {
+  color: inherit; text-decoration: none;
+  border-bottom: 1px solid var(--panel-line);
+  transition: color 0.2s, border-color 0.2s;
+}
+.then a:hover { color: var(--green); border-color: var(--green); }
+
+.cmd code {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px; color: #cbf6e6; white-space: nowrap; overflow-x: auto;
+  min-width: 0; scrollbar-width: none;
+}
+.cmd code::-webkit-scrollbar { display: none; }
+.cmd .prompt { color: var(--green); margin-right: 8px; user-select: none; }
+.copy {
+  flex: none; cursor: pointer; border: 1px solid var(--panel-line);
+  background: rgba(29, 180, 124, 0.12); color: var(--text);
+  border-radius: 8px; padding: 7px 12px; font-size: 13px; font-weight: 600;
+  transition: background 0.2s, transform 0.1s;
+}
+.copy:hover { background: rgba(29, 180, 124, 0.22); }
+.copy:active { transform: scale(0.96); }
+.copy.copied { color: var(--green); border-color: var(--green); }
+
+.cta { display: flex; flex-wrap: wrap; gap: 12px; }
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 12px 20px; border-radius: 11px; font-weight: 600; font-size: 15px;
+  transition: transform 0.12s, box-shadow 0.2s, background 0.2s;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary {
+  background: linear-gradient(120deg, var(--green), var(--blue));
+  color: #04231b; box-shadow: var(--glow);
+}
+.btn-primary:hover { box-shadow: 0 0 56px rgba(92, 199, 245, 0.5); }
+.btn-ghost {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--panel-line); backdrop-filter: blur(8px);
+}
+.btn-ghost:hover { background: rgba(29, 180, 124, 0.14); }
+
+/* ---- features ---- */
+.features {
+  position: relative; z-index: 2;
+  max-width: var(--maxw); margin: 0 auto; padding: 20px 24px 60px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px;
+}
+.card {
+  background: var(--panel); border: 1px solid var(--panel-line);
+  border-radius: var(--radius); padding: 22px; backdrop-filter: blur(8px);
+  transition: transform 0.2s, border-color 0.2s;
+}
+.card:hover { transform: translateY(-4px); border-color: rgba(92, 199, 245, 0.4); }
+.card h3 { margin: 0 0 8px; font-size: 18px; color: #eafff6; }
+.card p { margin: 0; color: var(--muted); font-size: 15px; line-height: 1.55; }
+.card code {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.86em;
+  color: var(--blue); background: rgba(92, 199, 245, 0.1);
+  padding: 1px 5px; border-radius: 5px;
+}
+
+/* ---- footer ---- */
+.foot {
+  position: relative; z-index: 2;
+  max-width: var(--maxw); margin: 0 auto; padding: 26px 24px 50px;
+  display: flex; justify-content: space-between; align-items: center;
+  color: var(--muted); font-size: 14px; border-top: 1px solid var(--panel-line);
+}
+.foot a:hover { color: var(--text); }
+
+/* ---- hummingbird hero animation ---- */
+/* The whole bird hovers. */
+.bird-body { animation: hover 4.6s ease-in-out infinite; transform-origin: center; }
+@keyframes hover {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-12px) rotate(-1.5deg); }
+}
+/* Near wing beats fast around its shoulder; the ghost wing pulses to suggest motion blur. */
+.wing-near { transform-box: fill-box; transform-origin: 2% 90%; animation: flap 0.5s ease-in-out infinite; }
+@keyframes flap {
+  0%, 100% { transform: rotate(-12deg); }
+  50% { transform: rotate(18deg); }
+}
+.wing-ghost { animation: ghost 0.5s ease-in-out infinite; }
+@keyframes ghost { 0%, 100% { opacity: 0.12; } 50% { opacity: 0.32; } }
+/* Tail steadies the hover with a slow wag. */
+.tail-fan { transform-box: fill-box; transform-origin: 6% 23%; animation: wag 4.6s ease-in-out infinite; }
+@keyframes wag {
+  0%, 100% { transform: rotate(-2.5deg); }
+  50% { transform: rotate(3deg); }
+}
+.eye-glint, .mig-glint { animation: twinkle 3.6s ease-in-out infinite; }
+@keyframes twinkle { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+
+/* ---- responsive ---- */
+@media (max-width: 880px) {
+  .hero { grid-template-columns: minmax(0, 1fr); text-align: center; min-height: auto; padding-top: 8px; gap: 8px; }
+  .hero-copy { width: 100%; margin: 0; }
+  .hero-stage { order: -1; margin-bottom: 6px; }
+  .bird { width: min(78%, 340px); }
+  .cta { justify-content: center; }
+  .tabs { justify-content: center; }
+  .cmd code { font-size: 12.5px; }
+  .features { grid-template-columns: 1fr; }
+  .nav-links { display: none; }
+  .foot { flex-direction: column; gap: 10px; }
+  .orb { opacity: 0.32; filter: blur(60px); }
+  .orb-a { width: 300px; height: 300px; }
+  .orb-b { width: 340px; height: 340px; right: -150px; }
+  .orb-c { width: 280px; height: 280px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orb, .bird-body, .wing-near, .wing-ghost, .tail-fan, .eye-glint, .mig-glint { animation: none !important; }
+  html { scroll-behavior: auto; }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,20 @@
+# Summary
+
+- [Introduction](introduction.md)
+
+# Guide
+
+- [Install](install.md)
+- [Quickstart](quickstart.md)
+- [The CLI](cli.md)
+- [Writing migrations](migrations.md)
+- [Transactions](transactions.md)
+- [Concurrency and locking](concurrency.md)
+- [Configuration](configuration.md)
+- [Database backends](backends.md)
+- [Troubleshooting](troubleshooting.md)
+
+# Library
+
+- [Using migrant_lib](library.md)
+- [Migration types](migration-types.md)

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -1,0 +1,55 @@
+# Database backends
+
+migrant supports SQLite, PostgreSQL, and MySQL. Each is behind a cargo feature so
+you only build the drivers you need.
+
+| Database | CLI feature | Library feature | Driver |
+|----------|-------------|-----------------|--------|
+| SQLite | `sqlite` | `d-sqlite` | rusqlite |
+| PostgreSQL | `postgres` | `d-postgres` | postgres |
+| MySQL | `mysql` | `d-mysql` | mysql |
+
+The library also has `d-all` to enable all three. No backend is enabled by
+default; invoking an operation whose feature is disabled returns
+`Error::FeatureRequired` rather than panicking.
+
+## SQLite
+
+File-backed or in-memory. The `sqlite` CLI feature bundles SQLite; the library's
+`d-sqlite` does not bundle it (enable rusqlite's `bundled` feature in your own
+project if you want that). DDL is transactional, so migrations roll back cleanly
+on failure.
+
+An in-memory database (`:memory:`) lives entirely in one connection. migrant
+keeps that connection alive for the life of the `Config` and its clones, so
+migrations and later queries see the same database. See
+[Using migrant_lib](library.md).
+
+## PostgreSQL
+
+DDL is transactional except for a handful of statements that cannot run in a
+transaction block (`CREATE INDEX CONCURRENTLY`, `ALTER TYPE ... ADD VALUE`,
+`VACUUM`, and similar). Opt those migrations out with the
+`-- migrant:no-transaction` directive; see [Transactions](transactions.md).
+
+TLS is chosen from the connection string's `sslmode`:
+
+- absent or `sslmode=disable`: no TLS (the default).
+- any other value (`prefer`/`require`/`verify-ca`/`verify-full`): TLS using the
+  system trust roots.
+- `ssl_cert_file` in the config: verify the server against that root certificate.
+
+The `postgres` driver needs `libpq`'s dev package (`libpq-dev`) to build.
+
+## MySQL / MariaDB
+
+DDL commits implicitly, one statement at a time. A transaction cannot roll back
+DDL, so transaction wrapping only makes pure-DML migrations atomic. This is a
+property of the database; the `-- migrant:no-transaction` directive and
+`no_transaction()` do not change it. Plan MySQL DDL migrations so a partial
+application is safe to retry.
+
+## Static builds
+
+The CLI's `vendored-openssl` feature statically links OpenSSL for portable
+(musl) builds. Release binaries are built with all features.

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,0 +1,74 @@
+# The CLI
+
+`migrant` manages migrations that live under `<project-dir>/migrations/`, where
+`project-dir` is the closest parent directory containing a `Migrant.toml`.
+Applied migrations are tracked in a `__migrant_migrations` table. Commands are
+run from anywhere inside the project; migrant searches upward for the config.
+
+## Project setup
+
+`migrant init [--type <sqlite|postgres|mysql>] [--location <dir>] [--default-from-env] [--no-confirm]`
+: Create a `Migrant.toml`. Run interactively (without `--no-confirm`) it also
+  runs `setup`. `--default-from-env` seeds every value as an `env:VAR` reference
+  instead of a literal (see [Configuration](configuration.md)).
+
+`migrant setup`
+: Verify database credentials and create the `__migrant_migrations` table if it
+  is missing.
+
+`migrant which-config`
+: Print the path of the active `Migrant.toml`.
+
+`migrant connect-string`
+: Print the connection string (server databases) or the database file path
+  (SQLite).
+
+## Migrations
+
+`migrant new <tag>`
+: Generate a timestamped `<stamp>_<tag>/` directory with empty `up.sql` and
+  `down.sql`. Tags may contain `[a-z0-9-]`.
+
+`migrant edit <tag> [--down]`
+: Open the `up.sql` (or `down.sql` with `--down`) for a migration matching
+  `<tag>` in `$EDITOR`.
+
+`migrant list`
+: List available migrations and mark those applied.
+
+`migrant apply [--down] [--all] [--force] [--fake]`
+: Apply the next migration. `--down` reverts instead of applying. `--all` runs
+  every remaining migration in the chosen direction. `--force` continues past
+  errors. `--fake` records the migration as (un)applied without running its SQL.
+
+`migrant redo [--all] [--force]`
+: Shortcut for the latest `down` then `up`. Useful while iterating on a migration
+  you are still writing.
+
+## Inspect and connect
+
+`migrant shell`
+: Open a database repl. Requires the matching client on your `PATH`: `sqlite3`
+  for SQLite, `psql` for PostgreSQL, `mysqlsh` for MySQL. The password is passed
+  out of band (`PGPASSWORD`/`MYSQL_PWD`), never on the command line.
+
+`migrant tui`
+: Interactive terminal UI for viewing and applying migrations.
+
+## Maintenance
+
+`migrant self update [--no-confirm] [--quiet]`
+: Replace the running binary with the latest GitHub release. Only works when the
+  binary was built with the `update` feature (release binaries are; a plain
+  `cargo install` is not).
+
+`migrant self bash-completions install [--path <path>]`
+: Generate a bash completion script (default `/etc/bash_completion.d/migrant`).
+
+## Behavior worth knowing
+
+- Each migration and its bookkeeping row are applied in one transaction by
+  default. See [Transactions](transactions.md) and the
+  `-- migrant:no-transaction` directive for DDL that cannot run in a transaction.
+- Runs against PostgreSQL/MySQL take an advisory lock so concurrent `migrant`
+  processes serialize. See [Concurrency and locking](concurrency.md).

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -1,0 +1,50 @@
+# Concurrency and locking
+
+When several processes run migrations against the same server database at once
+(a common case: multiple app instances applying migrations on boot), they must
+not race. migrant serializes them with a database advisory lock.
+
+## What happens
+
+For a run against PostgreSQL or MySQL, migrant takes a session-level advisory
+lock that it holds for the whole run:
+
+- PostgreSQL: `pg_advisory_lock`.
+- MySQL: `GET_LOCK` (blocks until the lock is available).
+
+A second migrator blocks until the first finishes, then proceeds. The lock is
+released when the run ends, and automatically by the database if the connection
+(session) drops, so a crashed migrator cannot leave a stuck lock.
+
+After taking the lock, migrant re-reads the applied migrations. A run that waited
+for a peer therefore observes the migrations that peer committed and does not
+re-apply them.
+
+SQLite has no advisory lock and no cross-process migration concurrency (a single
+connection already serializes writers), so locking is a no-op there.
+
+## Interaction with `--force`
+
+`migrant apply --force` continues past a failed migration. On a server database a
+failed statement is recovered in place (a rollback) rather than by dropping the
+connection, so the session, and the advisory lock it holds, survives the error. A
+`--force` run keeps holding the lock as it continues, with no window for another
+migrator to interleave.
+
+The one case where the lock is unavoidably lost mid-run is a genuinely dead
+connection. If the session ends, the database has already released the lock;
+migrant reconnects and continues, but that new session does not hold it.
+
+## Library control
+
+Runs are synchronized by default. The `Migrator::synchronized(bool)` builder
+toggles it, for example when an outer mechanism already serializes migrations:
+
+```rust
+Migrator::with_config(&config)
+    .synchronized(false) // opt out of the advisory lock
+    .all(true)
+    .apply()?;
+```
+
+See [Using migrant_lib](library.md) for the rest of the `Migrator` API.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,70 @@
+# Configuration
+
+A project is configured by a `Migrant.toml` file. The active config is found by
+searching upward from the current directory, so commands work from any
+subdirectory. `migrant which-config` prints the path in use.
+
+## Migrant.toml
+
+Keys:
+
+- `database_type` (required): `sqlite`, `postgres`, or `mysql`.
+- `migration_location`: directory holding migration folders. Default
+  `migrations`. A relative path resolves against the config file's directory.
+- SQLite: `database_path`. A relative path resolves against the config file's
+  directory.
+- Server databases: `database_name`, `database_user`, `database_password`,
+  `database_host`, `database_port`.
+- `database_params`: a table of extra connection parameters.
+- `ssl_cert_file` (PostgreSQL): path to a custom SSL certificate.
+
+### SQLite
+
+```toml
+database_type = "sqlite"
+database_path = "db/migrant.db"
+migration_location = "migrations"
+```
+
+### PostgreSQL
+
+```toml
+database_type = "postgres"
+database_name = "myapp"
+database_user = "myapp"
+database_password = "secret"
+database_host = "localhost"
+database_port = 5432
+migration_location = "migrations"
+
+[database_params]
+sslmode = "require"
+```
+
+MySQL uses the same server keys with `database_type = "mysql"`.
+
+## Environment variables
+
+Any value written as `env:VAR_NAME` is resolved from the environment when the
+config loads. Keep secrets out of the file:
+
+```toml
+database_password = "env:DB_PASSWORD"
+```
+
+`migrant init --default-from-env` seeds every value in this form.
+
+A `.env` file in scope is loaded automatically (via dotenvy) before values are
+resolved, so `env:` references can come from `.env` during local development.
+
+## Connection strings and SSL
+
+`migrant connect-string` prints the resolved connection string (or the file path
+for SQLite). Credentials and parameters are percent-encoded, so special
+characters in passwords and params are safe.
+
+For PostgreSQL, TLS is selected from the connection: `sslmode=disable` (or an
+absent `sslmode`) connects without TLS; any other `sslmode`
+(`prefer`/`require`/`verify-ca`/`verify-full`) connects with TLS using the system
+trust roots. `ssl_cert_file` verifies the server against a specific root
+certificate instead. See [Database backends](backends.md).

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -1,0 +1,53 @@
+# Install
+
+The `migrant` CLI builds without any database features by default, so pick at
+least one of `postgres` / `sqlite` / `mysql`. The `update` feature enables
+`migrant self update`, and `vendored-openssl` statically links OpenSSL for
+portable (musl) builds.
+
+## Binary releases
+
+Pre-built binaries for Linux (gnu and musl), macOS (x86_64 and aarch64), and
+Windows are attached to each [GitHub release](https://github.com/jaemk/migrant/releases).
+Release binaries are built with all features, so they can self-update:
+
+```sh
+migrant self update
+```
+
+## cargo
+
+```sh
+# with postgres
+cargo install migrant --features postgres
+
+# with bundled sqlite
+cargo install migrant --features sqlite
+
+# everything, including self-update
+cargo install migrant --features 'postgres sqlite mysql update'
+```
+
+Note that a `cargo install` without the `update` feature cannot self-update, and
+the `postgres` driver needs its dev library (`libpq-dev`). The `sqlite` feature
+bundles SQLite.
+
+## Docker
+
+An image with the binary installed is published as `jaemk/migrant:latest`:
+
+```sh
+docker run --rm jaemk/migrant:latest migrant --help
+```
+
+## As a library
+
+Add `migrant_lib` to your project and enable a backend feature. See
+[Using migrant_lib](library.md).
+
+```toml
+[dependencies]
+migrant_lib = { version = "0.35", features = ["d-postgres"] }
+```
+
+Next: the [Quickstart](quickstart.md).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,26 @@
+# Introduction
+
+`migrant` is database migration management for SQLite, PostgreSQL, and MySQL. It
+is two things that share one engine (`migrant_lib`):
+
+- A **CLI** (`migrant`) that manages plain `up.sql`/`down.sql` files under a
+  project directory, tracking applied migrations in a `__migrant_migrations`
+  table.
+- A **library** (`migrant_lib`) that embeds the same management in your own
+  application. Migrations can be SQL files, SQL strings compiled into the binary
+  (`include_str!`), or Rust functions.
+
+Migrations are applied in definition order (file migrations order by a timestamp
+in the tag). Each migration is applied together with its bookkeeping row in a
+single transaction by default, and concurrent migration runs against a server
+database serialize behind an advisory lock.
+
+This site is the reference for installing, using, and embedding `migrant`. Start
+with [Install](install.md) and the [Quickstart](quickstart.md). [The CLI](cli.md)
+is the full command reference and [Writing migrations](migrations.md) covers the
+file layout. For the behavior that matters most in production, see
+[Transactions](transactions.md) and [Concurrency and locking](concurrency.md).
+To embed migrant in your own program, see [Using migrant_lib](library.md).
+
+The normative behavior is the
+[spec](https://github.com/jaemk/migrant/tree/main/spec).

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -1,0 +1,89 @@
+# Using migrant_lib
+
+`migrant_lib` embeds migration management in your own program. The CLI is a thin
+wrapper around it, so anything the CLI does can be done from Rust. Enable a
+backend feature (`d-sqlite`, `d-postgres`, `d-mysql`, or `d-all`):
+
+```toml
+[dependencies]
+migrant_lib = { version = "0.35", features = ["d-postgres"] }
+```
+
+## The pieces
+
+- `Settings` describes the database connection, built with a typed builder or
+  loaded from a `Migrant.toml`.
+- `Config` holds the settings, the set of migrations, and a live connection. It
+  is cheap to clone; clones share the same connection.
+- `Migrator` applies migrations against a `Config`.
+
+## A minimal run
+
+```rust
+use migrant_lib::{Config, Migrator, Settings, EmbeddedMigration};
+
+# fn run() -> Result<(), Box<dyn std::error::Error>> {
+let settings = Settings::configure_sqlite()
+    .database_path("/abs/path/to/db.db")?
+    .build()?;
+
+let mut config = Config::with_settings(&settings);
+config.setup()?; // create the __migrant_migrations table
+
+config.use_migrations(&[
+    EmbeddedMigration::with_tag("create-users")
+        .up("create table users (id integer primary key, name text);")
+        .down("drop table users;")
+        .boxed(),
+])?;
+
+// Load applied state, then apply everything.
+let config = config.reload()?;
+Migrator::with_config(&config)
+    .all(true)
+    .apply()?;
+# Ok(())
+# }
+```
+
+`reload()` re-reads the applied set from the database and returns a fresh
+`Config`. Call it after `setup`/`use_migrations` and after each apply cycle.
+
+## Settings builders
+
+- `Settings::configure_sqlite()`: `database_path(...)`, `memory()` for an
+  in-memory database, `migration_location(...)`.
+- `Settings::configure_postgres()`: `database_name/user/password/host/port`,
+  `ssl_cert_file(...)`, `database_params(...)`.
+- `Settings::configure_mysql()`: the same name/user/password/host/port and
+  `database_params`.
+
+Or load from a file: `Config::from_settings_file("Migrant.toml")`.
+
+## The Migrator
+
+```rust
+Migrator::with_config(&config)
+    .direction(migrant_lib::Direction::Up) // or Down
+    .all(true)          // every remaining migration, not just the next
+    .force(false)       // continue past errors
+    .fake(false)        // record without running SQL
+    .synchronized(true) // advisory lock for server databases (default)
+    .show_output(true)
+    .apply()?;
+```
+
+`synchronized` controls the advisory lock; see
+[Concurrency and locking](concurrency.md). Transaction wrapping is per migration;
+see [Migration types](migration-types.md) and [Transactions](transactions.md).
+
+## In-memory SQLite
+
+The path `:memory:` (via `Settings::configure_sqlite().memory()`) selects an
+in-memory database. Its entire state lives in one connection, which the `Config`
+keeps alive and shares with its clones, so migrations and later queries see the
+same database. A function migration reaches it with
+`ConnConfig::sqlite_connection()`.
+
+See the [examples](https://github.com/jaemk/migrant/tree/main/migrant_lib/examples)
+for complete programs.

--- a/docs/src/migration-types.md
+++ b/docs/src/migration-types.md
@@ -1,0 +1,83 @@
+# Migration types
+
+`Config::use_migrations(&[...])` registers an explicit, ordered list of boxed
+`Migratable` values. Three types are built in.
+
+## FileMigration
+
+Runs `up`/`down` SQL loaded from files at runtime.
+
+```rust
+use migrant_lib::FileMigration;
+
+# fn run() -> Result<(), Box<dyn std::error::Error>> {
+FileMigration::with_tag("create-users")
+    .up("migrations/create_users/up.sql")?
+    .down("migrations/create_users/down.sql")?
+    .boxed();
+# Ok(())
+# }
+```
+
+The files must exist at runtime; relative paths resolve from the working
+directory.
+
+## EmbeddedMigration
+
+Runs `up`/`down` SQL from strings compiled into the binary, so no files are
+needed at runtime. `include_str!` embeds a file's contents.
+
+```rust
+use migrant_lib::EmbeddedMigration;
+
+# fn run() {
+EmbeddedMigration::with_tag("create-places")
+    .up(include_str!("../migrations/create_places/up.sql"))
+    .down("drop table places;")
+    .boxed();
+# }
+```
+
+## FnMigration
+
+Runs arbitrary Rust with the signature
+`fn(ConnConfig) -> Result<(), Box<dyn std::error::Error>>`. Use it for data
+migrations or anything SQL alone cannot express.
+
+```rust
+use migrant_lib::{FnMigration, ConnConfig};
+
+fn seed(conn: ConnConfig) -> Result<(), Box<dyn std::error::Error>> {
+    // open a connection from conn.connect_string()? / conn.sqlite_connection()?
+    Ok(())
+}
+
+# fn run() {
+FnMigration::with_tag("seed-users")
+    .up(seed)
+    .down(migrant_lib::migration::noop)
+    .boxed();
+# }
+```
+
+## Transactions per migration
+
+`Migratable::use_transaction(direction)` decides whether migrant wraps a
+migration in a transaction for that direction. The default is `true`.
+
+- `FileMigration` and `EmbeddedMigration` are wrapped by default. Opt out with
+  `no_transaction()` (both directions) or a `-- migrant:no-transaction` directive
+  in the SQL (per direction). A directive in the SQL takes precedence over the
+  builder flag.
+- `FnMigration` runs arbitrary code and may open its own connections, so it is
+  never wrapped.
+
+See [Transactions](transactions.md) for the directive rules and backend
+behavior.
+
+## Tags and CLI compatibility
+
+Tags must be unique and contain `[a-z0-9-]`. To interoperate with the `migrant`
+CLI (whose file migrations are timestamp-prefixed), call
+`Config::use_cli_compatible_tags(true)` before `use_migrations`/`reload`, which
+requires tags of the form `[0-9]{14}_[a-z0-9-]+`.

--- a/docs/src/migrations.md
+++ b/docs/src/migrations.md
@@ -1,0 +1,70 @@
+# Writing migrations
+
+A CLI migration is a directory holding an `up.sql` and a `down.sql`, named with a
+timestamp and a tag:
+
+```
+migrations/
+  20260713094500_create-users/
+    up.sql
+    down.sql
+  20260714101500_add-users-email/
+    up.sql
+    down.sql
+```
+
+`migrant new <tag>` generates the directory and the two empty files. The
+timestamp prefix defines application order: migrations apply oldest-first on the
+way up, newest-first on the way down. Tags may contain `[a-z0-9-]`.
+
+## up and down
+
+`up.sql` moves the schema forward; `down.sql` reverses it. Keep them inverses so
+`apply --down` cleanly undoes `apply`.
+
+```sql
+-- 20260714101500_add-users-email/up.sql
+alter table users add column email text;
+```
+
+```sql
+-- 20260714101500_add-users-email/down.sql
+alter table users drop column email;
+```
+
+Multiple statements per file are fine. Do not wrap them in your own
+`begin`/`commit`: migrant applies each migration inside a transaction already
+(see [Transactions](transactions.md)).
+
+## Order and the tracking table
+
+Applied migrations are recorded by tag in the `__migrant_migrations` table.
+`migrant list` reads that table to mark which migrations are applied:
+
+```
+Current Migration Status:
+ -> [✓] 20260713094500_create-users
+ -> [ ] 20260714101500_add-users-email
+```
+
+`apply` runs the next unapplied migration in timestamp order; `apply --all` runs
+the rest. `apply --down` reverts the most recently applied one.
+
+## Editing and iterating
+
+- `migrant edit <tag>` opens `up.sql` in `$EDITOR`; add `--down` for `down.sql`.
+- `migrant redo` re-runs the latest migration (down then up) so you can iterate
+  on SQL you are still writing.
+
+## Non-transactional DDL
+
+Some statements cannot run inside a transaction (for example PostgreSQL
+`CREATE INDEX CONCURRENTLY` or `ALTER TYPE ... ADD VALUE`). Put a directive at
+the top of that direction's file to opt it out:
+
+```sql
+-- migrant:no-transaction
+alter type mood add value 'excited';
+```
+
+See [Transactions](transactions.md) for the full rules.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart
+
+A file-based SQLite project from scratch. Every command is run from inside the
+project directory (the one holding `Migrant.toml`).
+
+## 1. Initialize
+
+```sh
+migrant init --type sqlite
+```
+
+This writes a `Migrant.toml` and, when run interactively, runs `setup` to create
+the `__migrant_migrations` tracking table. See [Configuration](configuration.md)
+for the file format and server-database options.
+
+## 2. Create a migration
+
+```sh
+migrant new create-users
+```
+
+This creates a timestamped directory under `migrations/` with empty `up.sql` and
+`down.sql` files:
+
+```
+migrations/
+  20260713094500_create-users/
+    up.sql
+    down.sql
+```
+
+Fill them in. Do not add your own `begin`/`commit`: migrant wraps each migration
+in a transaction (see [Transactions](transactions.md)).
+
+```sql
+-- up.sql
+create table users (id integer primary key, name text not null);
+```
+
+```sql
+-- down.sql
+drop table users;
+```
+
+## 3. Apply
+
+```sh
+migrant list          # show applied vs available
+migrant apply --all   # apply every pending up migration
+```
+
+`apply` moves one migration at a time by default; `--all` runs every remaining
+one. To revert, add `--down`:
+
+```sh
+migrant apply --down        # revert the most recent migration
+migrant apply --down --all  # revert everything
+```
+
+## 4. Inspect
+
+```sh
+migrant list            # status of each migration
+migrant which-config    # path of the active Migrant.toml
+migrant shell           # open a database repl (sqlite3/psql/mysqlsh)
+migrant tui             # interactive terminal UI
+```
+
+That is the whole loop: `new`, edit the SQL, `apply`. The full command reference
+is in [The CLI](cli.md).

--- a/docs/src/transactions.md
+++ b/docs/src/transactions.md
@@ -1,0 +1,86 @@
+# Transactions
+
+By default, migrant applies each migration's SQL and its `__migrant_migrations`
+bookkeeping row in a single transaction. The schema change and the record that it
+was applied commit or roll back together, so a migration that fails partway
+leaves neither partial schema nor a bookkeeping row. Do not add your own
+`begin`/`commit` to migration SQL; migrant manages the transaction.
+
+## What is wrapped
+
+Wrapping is resolved per direction (`up` vs `down`). The default is on. It covers
+the SQL migrant runs itself:
+
+- CLI file migrations (`up.sql`/`down.sql`).
+- Library `FileMigration` and `EmbeddedMigration`.
+
+Function migrations (`FnMigration`) run arbitrary Rust and may open their own
+connections, so migrant never wraps them.
+
+## Backend behavior
+
+The guarantee depends on how each backend treats DDL inside a transaction:
+
+| Backend | DDL in a transaction | Result |
+|---------|----------------------|--------|
+| SQLite | transactional | schema and DML roll back together |
+| PostgreSQL | transactional (with exceptions below) | schema and DML roll back together |
+| MySQL / MariaDB | implicit commit per DDL statement | only pure-DML migrations are atomic; DDL cannot roll back |
+
+On MySQL a `CREATE TABLE`/`ALTER TABLE` commits the moment it runs, so wrapping
+there makes only DML-only migrations atomic. This is a property of the database,
+not a setting.
+
+## Opting out: statements that cannot run in a transaction
+
+Some PostgreSQL statements refuse to run inside a transaction block, for example
+`CREATE INDEX CONCURRENTLY` and `ALTER TYPE ... ADD VALUE`. Wrapping such a
+migration would error. Opt the affected direction out.
+
+### From the SQL file (CLI and library)
+
+Put the directive on a comment line in that direction's SQL. This is the way to
+opt out from a CLI file migration, with no Rust code:
+
+```sql
+-- migrant:no-transaction
+alter type mood add value 'excited';
+```
+
+Rules:
+
+- Resolved per direction and per source: an `up.sql`/`down.sql` for a file
+  migration, the embedded string for an embedded migration. Put it only in the
+  direction that needs it.
+- Matched case-insensitively as the first token of a `--` comment, so a trailing
+  note is allowed: `-- migrant:no-transaction (enum add)`.
+- A directive in the SQL takes precedence over the builder flag below.
+
+### From Rust (library)
+
+`EmbeddedMigration` and `FileMigration` expose `no_transaction()`, which opts
+*both* directions out:
+
+```rust
+EmbeddedMigration::with_tag("add-index")
+    .up("create index concurrently idx_users_email on users (email);")
+    .down("drop index idx_users_email;")
+    .no_transaction()
+    .boxed();
+```
+
+For per-direction control, prefer the SQL directive. When both are present, the
+directive wins.
+
+## What opting out changes
+
+Without a transaction, a failed migration is not rolled back: earlier statements
+in the file stay applied. migrant still does not record the migration as applied
+when it fails, so a re-run will attempt it again. Write opted-out migrations so a
+partial application is safe to retry.
+
+## Interaction with locking
+
+Transaction wrapping is independent of the migration advisory lock. The lock
+spans the whole run and each migration's transaction nests inside it. See
+[Concurrency and locking](concurrency.md).

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+## `__migrant_migrations` table is missing
+
+Run `migrant setup` (or `Config::setup()` in the library) before applying
+migrations. It verifies credentials and creates the tracking table.
+
+## A PostgreSQL migration errors with "cannot run inside a transaction block"
+
+migrant wraps each migration in a transaction by default. Statements like
+`CREATE INDEX CONCURRENTLY` and `ALTER TYPE ... ADD VALUE` cannot run there. Put
+the directive at the top of that direction's SQL:
+
+```sql
+-- migrant:no-transaction
+alter type mood add value 'excited';
+```
+
+See [Transactions](transactions.md).
+
+## A MySQL migration was not rolled back on failure
+
+MySQL commits DDL implicitly, so a failed DDL migration is not rolled back. Only
+pure-DML migrations are atomic on MySQL. Write DDL migrations so a partial
+application is safe to retry. See [Database backends](backends.md#mysql--mariadb).
+
+## A second migrator seems to hang
+
+Against PostgreSQL/MySQL, migrant takes an advisory lock for the run. A second
+process blocks until the first releases it. This is expected: it prevents
+concurrent runs from racing. See [Concurrency and locking](concurrency.md). If a
+process truly died holding the lock, the database releases it when that session
+ends.
+
+## `migrant self update` says it is unavailable
+
+Self-update only works when the binary was built with the `update` feature.
+Release binaries include it; `cargo install migrant --features postgres` (for
+example) does not. Reinstall from a [release](https://github.com/jaemk/migrant/releases)
+or add the `update` feature.
+
+## `migrant shell` cannot find the client
+
+`shell` runs the database's own client: `sqlite3`, `psql`, or `mysqlsh`. Install
+the matching client and make sure it is on your `PATH`.
+
+## Wrong config is picked up
+
+migrant searches upward from the current directory for `Migrant.toml`. Run
+`migrant which-config` to see which file is active.

--- a/migrant_lib/src/config/mod.rs
+++ b/migrant_lib/src/config/mod.rs
@@ -103,11 +103,17 @@ impl Config {
         let conn = guard.as_mut().expect("connection just established");
         let res = f(conn);
         if res.is_err() && self.database_type() != DbKind::Sqlite {
-            // Drop server connections on error: they may be stuck in an
-            // aborted-transaction state. The next operation reconnects.
-            // Sqlite connections are kept (rollback is handled by the driver,
-            // and an in-memory database would be lost).
-            *guard = None;
+            // A server error may leave the connection stuck in an
+            // aborted-transaction state. Recover it in place with a rollback
+            // rather than dropping it, so session-scoped state -- notably the
+            // migration advisory lock -- survives the error and is still held
+            // when a `force`d run continues past it. Only if the rollback fails
+            // (a genuinely dead connection) do we drop it, so the next
+            // operation reconnects. Sqlite is excluded: its driver handles
+            // rollback and an in-memory database would be lost if dropped.
+            if conn.rollback().is_err() {
+                *guard = None;
+            }
         }
         res
     }
@@ -115,6 +121,41 @@ impl Config {
     /// Execute a batch of sql statements on the database
     pub(crate) fn execute_sql(&self, sql: &str) -> Result<()> {
         self.with_conn(|conn| conn.execute_batch(sql))
+    }
+
+    /// Begin a transaction on the live connection
+    pub(crate) fn begin_transaction(&self) -> Result<()> {
+        self.with_conn(|conn| conn.begin())
+    }
+
+    /// Commit the current transaction on the live connection
+    pub(crate) fn commit_transaction(&self) -> Result<()> {
+        self.with_conn(|conn| conn.commit())
+    }
+
+    /// Roll back the current transaction on the live connection.
+    ///
+    /// Best-effort: this runs on error paths where the connection may already
+    /// have been torn down (which itself rolls back the transaction on server
+    /// databases), so failures to issue an explicit `rollback` are ignored.
+    pub(crate) fn rollback_transaction(&self) {
+        let _ = self.with_conn(|conn| conn.rollback());
+    }
+
+    /// Acquire the session-level advisory lock that serializes migration runs.
+    /// Blocks until the lock is available. No-op for sqlite.
+    pub(crate) fn acquire_migration_lock(&self) -> Result<()> {
+        self.with_conn(|conn| conn.acquire_lock())
+    }
+
+    /// Release the migration advisory lock.
+    ///
+    /// Best-effort: server databases release session-level locks automatically
+    /// when the connection drops, so failures to issue an explicit unlock (for
+    /// example after the connection was reconnected on an error path) are
+    /// ignored.
+    pub(crate) fn release_migration_lock(&self) {
+        let _ = self.with_conn(|conn| conn.release_lock());
     }
 
     /// Return a shared handle to the live sqlite connection,

--- a/migrant_lib/src/drivers/mod.rs
+++ b/migrant_lib/src/drivers/mod.rs
@@ -153,6 +153,34 @@ impl DbConnection {
     pub(crate) fn execute_batch(&mut self, sql: &str) -> Result<()> {
         dispatch!(self, c => c.execute_batch(sql))
     }
+
+    /// Begin a transaction on this connection
+    pub(crate) fn begin(&mut self) -> Result<()> {
+        dispatch!(self, c => c.begin())
+    }
+
+    /// Commit the current transaction on this connection
+    pub(crate) fn commit(&mut self) -> Result<()> {
+        dispatch!(self, c => c.commit())
+    }
+
+    /// Roll back the current transaction on this connection
+    pub(crate) fn rollback(&mut self) -> Result<()> {
+        dispatch!(self, c => c.rollback())
+    }
+
+    /// Acquire the session-level advisory lock that serializes migration runs.
+    ///
+    /// Blocks until the lock is available. Sqlite has no advisory lock (and no
+    /// cross-process migration concurrency to guard against), so it is a no-op.
+    pub(crate) fn acquire_lock(&mut self) -> Result<()> {
+        dispatch!(self, c => c.acquire_lock())
+    }
+
+    /// Release the session-level advisory lock. No-op for sqlite.
+    pub(crate) fn release_lock(&mut self) -> Result<()> {
+        dispatch!(self, c => c.release_lock())
+    }
 }
 
 #[cfg(test)]

--- a/migrant_lib/src/drivers/mysql.rs
+++ b/migrant_lib/src/drivers/mysql.rs
@@ -7,6 +7,13 @@ use super::sql;
 use crate::errors::*;
 use crate::macros::{bail, err};
 
+/// Named advisory lock that serializes concurrent migration runs.
+///
+/// MySQL `GET_LOCK`/`RELEASE_LOCK` are keyed by name and scoped to the session,
+/// so the lock is released automatically if this connection drops. The name is
+/// arbitrary but must be identical across every process using this library.
+const ADVISORY_LOCK_NAME: &str = "__migrant_migrations";
+
 /// A live mysql connection
 pub(crate) struct MySqlConn {
     conn: Conn,
@@ -62,6 +69,48 @@ impl MySqlConn {
             .query_drop(stmt)
             .map_err(|e| err!(Migration, "{}", e))
     }
+
+    pub(crate) fn begin(&mut self) -> Result<()> {
+        self.conn
+            .query_drop("begin")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn commit(&mut self) -> Result<()> {
+        self.conn
+            .query_drop("commit")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn rollback(&mut self) -> Result<()> {
+        self.conn
+            .query_drop("rollback")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    /// Take the named advisory lock, blocking until it is available (a negative
+    /// `GET_LOCK` timeout waits indefinitely). MySQL releases it automatically
+    /// if this connection (session) drops.
+    pub(crate) fn acquire_lock(&mut self) -> Result<()> {
+        let got: Option<Option<i64>> = self
+            .conn
+            .query_first(format!("select get_lock('{}', -1)", ADVISORY_LOCK_NAME))
+            .map_err(|e| err!(Migration, "{}", e))?;
+        match got {
+            Some(Some(1)) => Ok(()),
+            _ => bail!(
+                Migration,
+                "could not acquire mysql advisory lock `{}`",
+                ADVISORY_LOCK_NAME
+            ),
+        }
+    }
+
+    pub(crate) fn release_lock(&mut self) -> Result<()> {
+        self.conn
+            .query_drop(format!("select release_lock('{}')", ADVISORY_LOCK_NAME))
+            .map_err(|e| err!(Migration, "{}", e))
+    }
 }
 
 #[cfg(test)]
@@ -107,5 +156,43 @@ mod tests {
 
         conn.execute_batch("drop table __migrant_migrations;")
             .unwrap();
+    }
+
+    /// The advisory lock is exclusive across connections: while one session
+    /// holds it, another cannot, and it becomes available again once released.
+    /// Requires a running mysql instance (`MYSQL_TEST_CONN_STR`).
+    #[test]
+    fn advisory_lock_is_exclusive() {
+        let conn_str = match std::env::var("MYSQL_TEST_CONN_STR") {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!("MYSQL_TEST_CONN_STR not set, skipping");
+                return;
+            }
+        };
+        let mut holder = MySqlConn::connect(&conn_str).unwrap();
+        let mut other = MySqlConn::connect(&conn_str).unwrap();
+
+        // `get_lock` with a zero timeout returns immediately: 1 got it, 0 timed out.
+        let try_lock = |c: &mut MySqlConn| -> Option<i64> {
+            c.conn
+                .query_first(format!("select get_lock('{}', 0)", ADVISORY_LOCK_NAME))
+                .unwrap()
+                .flatten()
+        };
+
+        holder.acquire_lock().unwrap();
+        assert_eq!(
+            Some(0),
+            try_lock(&mut other),
+            "second session must not acquire a held lock"
+        );
+        holder.release_lock().unwrap();
+        assert_eq!(
+            Some(1),
+            try_lock(&mut other),
+            "lock must be available once released"
+        );
+        other.release_lock().unwrap();
     }
 }

--- a/migrant_lib/src/drivers/pg.rs
+++ b/migrant_lib/src/drivers/pg.rs
@@ -9,6 +9,13 @@ use super::sql;
 use crate::errors::*;
 use crate::macros::err;
 
+/// Session-level advisory lock key that serializes concurrent migration runs.
+///
+/// The value is arbitrary but must be identical across every process using
+/// this library so they contend for the same lock. `pg_advisory_lock` takes a
+/// single `bigint`; this constant is stable and namespaced to migrant.
+const ADVISORY_LOCK_KEY: i64 = 30_796_665_483_397_364;
+
 /// A live postgres connection
 pub(crate) struct PgConn {
     client: Client,
@@ -116,6 +123,40 @@ impl PgConn {
             .batch_execute(stmt)
             .map_err(|e| err!(Migration, "{}", e))
     }
+
+    pub(crate) fn begin(&mut self) -> Result<()> {
+        self.client
+            .batch_execute("begin")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn commit(&mut self) -> Result<()> {
+        self.client
+            .batch_execute("commit")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn rollback(&mut self) -> Result<()> {
+        self.client
+            .batch_execute("rollback")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    /// Take the session-level advisory lock, blocking until it is available.
+    /// Postgres releases it automatically if this connection (session) drops.
+    pub(crate) fn acquire_lock(&mut self) -> Result<()> {
+        self.client
+            .execute("select pg_advisory_lock($1)", &[&ADVISORY_LOCK_KEY])
+            .map_err(|e| err!(Migration, "{}", e))?;
+        Ok(())
+    }
+
+    pub(crate) fn release_lock(&mut self) -> Result<()> {
+        self.client
+            .execute("select pg_advisory_unlock($1)", &[&ADVISORY_LOCK_KEY])
+            .map_err(|e| err!(Migration, "{}", e))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -201,6 +242,93 @@ mod tests {
         assert_eq!(0, conn.applied_tags().unwrap().len());
 
         conn.execute_batch("drop table __migrant_migrations;")
+            .unwrap();
+    }
+
+    /// Advisory-lock behavior. Both scenarios share the one fixed lock key, so
+    /// they run as a single test rather than racing each other for it under
+    /// cargo's parallel runner. Requires a running postgres instance
+    /// (`POSTGRES_TEST_CONN_STR`).
+    #[test]
+    fn advisory_lock() {
+        let conn_str = match std::env::var("POSTGRES_TEST_CONN_STR") {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!("POSTGRES_TEST_CONN_STR not set, skipping");
+                return;
+            }
+        };
+        lock_is_exclusive(&conn_str);
+        lock_survives_in_transaction_error(&conn_str);
+    }
+
+    /// While one session holds the lock, another cannot, and it becomes
+    /// available again once released.
+    fn lock_is_exclusive(conn_str: &str) {
+        let mut holder = PgConn::connect(conn_str, None).unwrap();
+        let mut other = PgConn::connect(conn_str, None).unwrap();
+
+        // `pg_try_advisory_lock` returns immediately with whether it got the lock.
+        let try_lock = |c: &mut PgConn| -> bool {
+            c.client
+                .query_one("select pg_try_advisory_lock($1)", &[&ADVISORY_LOCK_KEY])
+                .unwrap()
+                .get(0)
+        };
+
+        holder.acquire_lock().unwrap();
+        assert!(
+            !try_lock(&mut other),
+            "second session must not acquire a held lock"
+        );
+        holder.release_lock().unwrap();
+        assert!(try_lock(&mut other), "lock must be available once released");
+        // release the try-lock we just took so we don't leak it on the session
+        other
+            .client
+            .execute("select pg_advisory_unlock($1)", &[&ADVISORY_LOCK_KEY])
+            .unwrap();
+    }
+
+    /// After an error inside a transaction, recovering the connection in place
+    /// with `rollback` (as `Config::with_conn` does) keeps the session alive, so
+    /// the advisory lock it holds survives the error and the connection stays
+    /// usable. This is what lets a `force`d migration run keep holding the lock
+    /// past a failed migration.
+    fn lock_survives_in_transaction_error(conn_str: &str) {
+        let mut holder = PgConn::connect(conn_str, None).unwrap();
+        let mut other = PgConn::connect(conn_str, None).unwrap();
+
+        holder.acquire_lock().unwrap();
+        // Provoke an error inside an explicit transaction: postgres leaves the
+        // connection in an aborted-transaction state.
+        holder.begin().unwrap();
+        assert!(holder
+            .execute_batch("select * from does_not_exist")
+            .is_err());
+        // Recover in place, exactly as `with_conn` does on a server error.
+        holder.rollback().unwrap();
+
+        // The session survived, so it still holds the lock and another session
+        // cannot take it (`not pg_try_advisory_lock` is true when it is held).
+        let still_held: bool = other
+            .client
+            .query_one("select not pg_try_advisory_lock($1)", &[&ADVISORY_LOCK_KEY])
+            .unwrap()
+            .get(0);
+        assert!(
+            still_held,
+            "advisory lock must survive an in-transaction error"
+        );
+        // The recovered connection is usable again.
+        let one: i32 = holder.client.query_one("select 1", &[]).unwrap().get(0);
+        assert_eq!(1, one);
+
+        holder.release_lock().unwrap();
+        // Drop any advisory locks `other` may have taken so none leak on its session.
+        other
+            .client
+            .execute("select pg_advisory_unlock_all()", &[])
             .unwrap();
     }
 }

--- a/migrant_lib/src/drivers/sqlite.rs
+++ b/migrant_lib/src/drivers/sqlite.rs
@@ -97,6 +97,35 @@ impl SqliteConn {
         }
         res.map_err(|e| err!(Migration, "{}", e))
     }
+
+    pub(crate) fn begin(&self) -> Result<()> {
+        self.lock()
+            .execute_batch("begin")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn commit(&self) -> Result<()> {
+        self.lock()
+            .execute_batch("commit")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    pub(crate) fn rollback(&self) -> Result<()> {
+        self.lock()
+            .execute_batch("rollback")
+            .map_err(|e| err!(Migration, "{}", e))
+    }
+
+    /// Sqlite has no cross-process advisory lock (a single connection already
+    /// serializes writers, and there is no server to coordinate through), so
+    /// migration-run locking is a no-op.
+    pub(crate) fn acquire_lock(&self) -> Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn release_lock(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/migrant_lib/src/migratable.rs
+++ b/migrant_lib/src/migratable.rs
@@ -40,22 +40,26 @@ pub trait Migratable: MigratableClone {
         self.tag()
     }
 
-    /// Whether the migrator should wrap this migration's application and its
-    /// bookkeeping row (the insert/delete in `__migrant_migrations`) in a
-    /// single database transaction, so the two commit or roll back together.
+    /// Whether the migrator should wrap this migration's application in the
+    /// given `direction`, together with its bookkeeping row (the insert/delete
+    /// in `__migrant_migrations`), in a single database transaction so the two
+    /// commit or roll back together.
     ///
-    /// Defaults to `true`. Override to `false` for migrations the migrator
-    /// cannot meaningfully wrap in one transaction on its own connection --
-    /// for example arbitrary-code migrations (`FnMigration` returns `false`),
-    /// or statements a backend refuses to run inside a transaction block
-    /// (e.g. Postgres `CREATE INDEX CONCURRENTLY`). See `no_transaction` on
+    /// Defaults to `true` for both directions. Override to return `false` for a
+    /// direction the migrator cannot meaningfully wrap in one transaction on its
+    /// own connection -- for example arbitrary-code migrations (`FnMigration`
+    /// returns `false`), or statements a backend refuses to run inside a
+    /// transaction block (e.g. Postgres `CREATE INDEX CONCURRENTLY` or
+    /// `ALTER TYPE ... ADD VALUE`). See `no_transaction` and the
+    /// `-- migrant:no-transaction` file directive on
     /// [`EmbeddedMigration`](crate::EmbeddedMigration) and
     /// [`FileMigration`](crate::FileMigration).
     ///
     /// Note: MySQL/MariaDB commit DDL implicitly, so transactional wrapping
     /// there only makes pure-DML migrations atomic; DDL cannot be rolled back
     /// regardless of this setting.
-    fn use_transaction(&self) -> bool {
+    fn use_transaction(&self, direction: Direction) -> bool {
+        let _ = direction;
         true
     }
 }

--- a/migrant_lib/src/migratable.rs
+++ b/migrant_lib/src/migratable.rs
@@ -39,6 +39,25 @@ pub trait Migratable: MigratableClone {
     fn description(&self, _: &Direction) -> String {
         self.tag()
     }
+
+    /// Whether the migrator should wrap this migration's application and its
+    /// bookkeeping row (the insert/delete in `__migrant_migrations`) in a
+    /// single database transaction, so the two commit or roll back together.
+    ///
+    /// Defaults to `true`. Override to `false` for migrations the migrator
+    /// cannot meaningfully wrap in one transaction on its own connection --
+    /// for example arbitrary-code migrations (`FnMigration` returns `false`),
+    /// or statements a backend refuses to run inside a transaction block
+    /// (e.g. Postgres `CREATE INDEX CONCURRENTLY`). See `no_transaction` on
+    /// [`EmbeddedMigration`](crate::EmbeddedMigration) and
+    /// [`FileMigration`](crate::FileMigration).
+    ///
+    /// Note: MySQL/MariaDB commit DDL implicitly, so transactional wrapping
+    /// there only makes pure-DML migrations atomic; DDL cannot be rolled back
+    /// regardless of this setting.
+    fn use_transaction(&self) -> bool {
+        true
+    }
 }
 
 impl Clone for Box<dyn Migratable> {

--- a/migrant_lib/src/migration.rs
+++ b/migrant_lib/src/migration.rs
@@ -14,6 +14,45 @@ use crate::migratable::Migratable;
 use crate::migrator::Direction;
 use crate::DT_FORMAT;
 
+/// SQL comment directive that opts a single migration direction out of the
+/// migrator's automatic transaction wrapping.
+///
+/// Placed on its own `--` comment line in a direction's SQL (an `up.sql` /
+/// `down.sql` file, or the embedded string for that direction), e.g:
+///
+/// ```sql
+/// -- migrant:no-transaction
+/// alter type mood add value 'excited';
+/// ```
+pub(crate) const NO_TRANSACTION_DIRECTIVE: &str = "migrant:no-transaction";
+
+/// Return `true` if `sql` carries the [`NO_TRANSACTION_DIRECTIVE`] on a comment
+/// line. It is matched case-insensitively as the first token of a `--` line
+/// comment, so a trailing explanation is allowed
+/// (`-- migrant:no-transaction (enum add)`).
+pub(crate) fn sql_opts_out_of_transaction(sql: &str) -> bool {
+    sql.lines().any(|line| {
+        matches!(
+            line.trim()
+                .strip_prefix("--")
+                .and_then(|rest| rest.split_whitespace().next()),
+            Some(token) if token.eq_ignore_ascii_case(NO_TRANSACTION_DIRECTIVE)
+        )
+    })
+}
+
+/// Whether the migration file at `path` declares the no-transaction directive.
+/// A missing or unreadable file is treated as not opting out; the subsequent
+/// apply surfaces any real read error.
+fn file_opts_out_of_transaction(path: &Option<PathBuf>) -> bool {
+    match path {
+        Some(p) => std::fs::read_to_string(p)
+            .map(|sql| sql_opts_out_of_transaction(&sql))
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
 /// Define a migration that uses SQL statements saved in files.
 ///
 /// *Note:* Files defined in this migration must be present at run-time.
@@ -22,9 +61,13 @@ use crate::DT_FORMAT;
 ///
 /// *Note:* By default the migrator wraps this migration's SQL and its
 /// bookkeeping row in a single transaction, so do **not** add your own
-/// `begin`/`commit` to the SQL. Call [`no_transaction`](FileMigration::no_transaction)
-/// for migrations that must not run inside a transaction block (for example a
-/// Postgres `CREATE INDEX CONCURRENTLY`).
+/// `begin`/`commit` to the SQL. To opt a direction out (for statements a backend
+/// refuses to run in a transaction block, e.g. a Postgres `CREATE INDEX
+/// CONCURRENTLY` or `ALTER TYPE ... ADD VALUE`), put the directive
+/// `-- migrant:no-transaction` on a comment line in that direction's SQL file,
+/// or call [`no_transaction`](FileMigration::no_transaction) to opt out both
+/// directions. A file directive takes precedence over the builder flag, so it
+/// works for migrations discovered from disk by the `migrant` CLI.
 #[derive(Clone, Debug)]
 pub struct FileMigration {
     /// Migration tag
@@ -49,11 +92,15 @@ impl FileMigration {
         }
     }
 
-    /// Opt this migration out of the migrator's automatic transaction wrapping.
+    /// Opt both of this migration's directions out of the migrator's automatic
+    /// transaction wrapping.
     ///
     /// Use this for statements a backend refuses to run inside a transaction
-    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. When opted out, the
-    /// migration's SQL and its bookkeeping row are no longer applied atomically.
+    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. For per-direction
+    /// control, put the `-- migrant:no-transaction` directive on a comment line
+    /// in the relevant SQL file instead; a file directive takes precedence over
+    /// this flag. When opted out, that direction's SQL and its bookkeeping row
+    /// are no longer applied atomically.
     pub fn no_transaction(&mut self) -> &mut Self {
         self.no_transaction = true;
         self
@@ -133,7 +180,16 @@ impl Migratable for FileMigration {
             .unwrap_or_else(|| self.tag())
     }
 
-    fn use_transaction(&self) -> bool {
+    fn use_transaction(&self, direction: Direction) -> bool {
+        let file = match direction {
+            Direction::Up => &self.up,
+            Direction::Down => &self.down,
+        };
+        // A directive in the migration file takes precedence over the
+        // builder-level `no_transaction` flag.
+        if file_opts_out_of_transaction(file) {
+            return false;
+        }
         !self.no_transaction
     }
 }
@@ -147,9 +203,13 @@ impl Migratable for FileMigration {
 ///
 /// *Note:* By default the migrator wraps this migration's SQL and its
 /// bookkeeping row in a single transaction, so do **not** add your own
-/// `begin`/`commit` to the SQL. Call [`no_transaction`](EmbeddedMigration::no_transaction)
-/// for migrations that must not run inside a transaction block (for example a
-/// Postgres `CREATE INDEX CONCURRENTLY`).
+/// `begin`/`commit` to the SQL. To opt a direction out (for statements a backend
+/// refuses to run in a transaction block, e.g. a Postgres `CREATE INDEX
+/// CONCURRENTLY` or `ALTER TYPE ... ADD VALUE`), put the directive
+/// `-- migrant:no-transaction` on a comment line in that direction's SQL (it
+/// travels with an `include_str!`ed file), or call
+/// [`no_transaction`](EmbeddedMigration::no_transaction) to opt out both
+/// directions. A directive in the SQL takes precedence over the builder flag.
 ///
 /// A database feature (`d-postgres` / `d-sqlite` / `d-mysql`) is required to
 /// apply this type of migration.
@@ -199,11 +259,15 @@ impl EmbeddedMigration {
         }
     }
 
-    /// Opt this migration out of the migrator's automatic transaction wrapping.
+    /// Opt both of this migration's directions out of the migrator's automatic
+    /// transaction wrapping.
     ///
     /// Use this for statements a backend refuses to run inside a transaction
-    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. When opted out, the
-    /// migration's SQL and its bookkeeping row are no longer applied atomically.
+    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. For per-direction
+    /// control, put the `-- migrant:no-transaction` directive on a comment line
+    /// in the relevant direction's SQL instead; a directive in the SQL takes
+    /// precedence over this flag. When opted out, that direction's SQL and its
+    /// bookkeeping row are no longer applied atomically.
     pub fn no_transaction(&mut self) -> &mut Self {
         self.no_transaction = true;
         self
@@ -250,7 +314,20 @@ impl Migratable for EmbeddedMigration {
         self.tag()
     }
 
-    fn use_transaction(&self) -> bool {
+    fn use_transaction(&self, direction: Direction) -> bool {
+        let sql = match direction {
+            Direction::Up => &self.up,
+            Direction::Down => &self.down,
+        };
+        // A directive embedded in this direction's SQL takes precedence over the
+        // builder-level `no_transaction` flag.
+        let declared = match sql {
+            Some(s) => sql_opts_out_of_transaction(s),
+            None => false,
+        };
+        if declared {
+            return false;
+        }
         !self.no_transaction
     }
 }
@@ -363,7 +440,63 @@ where
     /// Function migrations run arbitrary code (and may open their own
     /// connections), so the migrator cannot wrap them in a single transaction
     /// on its connection. Always `false`.
-    fn use_transaction(&self) -> bool {
+    fn use_transaction(&self, _direction: Direction) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_no_transaction_directive() {
+        assert!(sql_opts_out_of_transaction(
+            "-- migrant:no-transaction\ncreate table t (x integer);"
+        ));
+        // no space after the comment marker
+        assert!(sql_opts_out_of_transaction("--migrant:no-transaction"));
+        // case-insensitive
+        assert!(sql_opts_out_of_transaction("-- MIGRANT:No-Transaction"));
+        // a trailing explanation is allowed
+        assert!(sql_opts_out_of_transaction(
+            "-- migrant:no-transaction (enum add)\nalter type mood add value 'x';"
+        ));
+        // not required to be the first line
+        assert!(sql_opts_out_of_transaction(
+            "create table t (x integer);\n-- migrant:no-transaction"
+        ));
+    }
+
+    #[test]
+    fn ignores_absent_or_unrelated_directive() {
+        assert!(!sql_opts_out_of_transaction("create table t (x integer);"));
+        assert!(!sql_opts_out_of_transaction("-- just a normal comment"));
+        // a longer token that merely starts with the directive must not match
+        assert!(!sql_opts_out_of_transaction(
+            "-- migrant:no-transaction-please"
+        ));
+        // the text appearing outside a comment must not match
+        assert!(!sql_opts_out_of_transaction(
+            "select 'migrant:no-transaction';"
+        ));
+        assert!(!sql_opts_out_of_transaction(""));
+    }
+
+    #[test]
+    fn embedded_use_transaction_is_per_direction_and_directive_wins() {
+        // `up` opts out via directive, `down` does not: transactionality differs
+        // by direction, and the directive overrides the (unset) builder flag.
+        let mut m = EmbeddedMigration::with_tag("m");
+        m.up("-- migrant:no-transaction\nalter type mood add value 'x';")
+            .down("drop type mood;");
+        assert!(!m.use_transaction(Direction::Up));
+        assert!(m.use_transaction(Direction::Down));
+
+        // builder-level opt-out applies to any direction without a directive
+        let mut m2 = EmbeddedMigration::with_tag("m2");
+        m2.up("select 1;").down("select 1;").no_transaction();
+        assert!(!m2.use_transaction(Direction::Up));
+        assert!(!m2.use_transaction(Direction::Down));
     }
 }

--- a/migrant_lib/src/migration.rs
+++ b/migrant_lib/src/migration.rs
@@ -20,9 +20,11 @@ use crate::DT_FORMAT;
 /// File paths can be absolute or relative. Relative file paths are relative
 /// to the directory from which the program is run.
 ///
-/// *Note:* SQL statements are batch executed as is. If you want your migration
-/// to happen atomically in a transaction you should manually wrap your statements
-/// in a transaction (`begin transaction; ... commit;`).
+/// *Note:* By default the migrator wraps this migration's SQL and its
+/// bookkeeping row in a single transaction, so do **not** add your own
+/// `begin`/`commit` to the SQL. Call [`no_transaction`](FileMigration::no_transaction)
+/// for migrations that must not run inside a transaction block (for example a
+/// Postgres `CREATE INDEX CONCURRENTLY`).
 #[derive(Clone, Debug)]
 pub struct FileMigration {
     /// Migration tag
@@ -32,6 +34,7 @@ pub struct FileMigration {
     /// Path to a `down` migration file
     pub down: Option<PathBuf>,
     pub(crate) stamp: Option<DateTime<Utc>>,
+    pub(crate) no_transaction: bool,
 }
 
 impl FileMigration {
@@ -42,7 +45,18 @@ impl FileMigration {
             up: None,
             down: None,
             stamp: None,
+            no_transaction: false,
         }
+    }
+
+    /// Opt this migration out of the migrator's automatic transaction wrapping.
+    ///
+    /// Use this for statements a backend refuses to run inside a transaction
+    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. When opted out, the
+    /// migration's SQL and its bookkeeping row are no longer applied atomically.
+    pub fn no_transaction(&mut self) -> &mut Self {
+        self.no_transaction = true;
+        self
     }
 
     fn check_path(path: &Path) -> Result<()> {
@@ -118,6 +132,10 @@ impl Migratable for FileMigration {
             .map(|p| format!("{:?}", p))
             .unwrap_or_else(|| self.tag())
     }
+
+    fn use_transaction(&self) -> bool {
+        !self.no_transaction
+    }
 }
 
 /// Define an embedded migration
@@ -127,9 +145,11 @@ impl Migratable for FileMigration {
 /// standard [`include_str!`](https://doc.rust-lang.org/std/macro.include_str.html) macro
 /// can be used to embed contents of files, or a string literal can be provided.
 ///
-/// *Note:* SQL statements are batch executed as is. If you want your migration
-/// to happen atomically in a transaction you should manually wrap your statements
-/// in a transaction (`begin transaction; ... commit;`).
+/// *Note:* By default the migrator wraps this migration's SQL and its
+/// bookkeeping row in a single transaction, so do **not** add your own
+/// `begin`/`commit` to the SQL. Call [`no_transaction`](EmbeddedMigration::no_transaction)
+/// for migrations that must not run inside a transaction block (for example a
+/// Postgres `CREATE INDEX CONCURRENTLY`).
 ///
 /// A database feature (`d-postgres` / `d-sqlite` / `d-mysql`) is required to
 /// apply this type of migration.
@@ -165,6 +185,7 @@ pub struct EmbeddedMigration {
     pub up: Option<Cow<'static, str>>,
     /// Statements to run for `down` migrations
     pub down: Option<Cow<'static, str>>,
+    pub(crate) no_transaction: bool,
 }
 
 impl EmbeddedMigration {
@@ -174,7 +195,18 @@ impl EmbeddedMigration {
             tag: tag.to_owned(),
             up: None,
             down: None,
+            no_transaction: false,
         }
+    }
+
+    /// Opt this migration out of the migrator's automatic transaction wrapping.
+    ///
+    /// Use this for statements a backend refuses to run inside a transaction
+    /// block, such as Postgres `CREATE INDEX CONCURRENTLY`. When opted out, the
+    /// migration's SQL and its bookkeeping row are no longer applied atomically.
+    pub fn no_transaction(&mut self) -> &mut Self {
+        self.no_transaction = true;
+        self
     }
 
     /// `&'static str` or `String` of statements to use for `up` migrations
@@ -216,6 +248,10 @@ impl Migratable for EmbeddedMigration {
 
     fn description(&self, _: &Direction) -> String {
         self.tag()
+    }
+
+    fn use_transaction(&self) -> bool {
+        !self.no_transaction
     }
 }
 
@@ -322,5 +358,12 @@ where
 
     fn description(&self, _: &Direction) -> String {
         self.tag()
+    }
+
+    /// Function migrations run arbitrary code (and may open their own
+    /// connections), so the migrator cannot wrap them in a single transaction
+    /// on its connection. Always `false`.
+    fn use_transaction(&self) -> bool {
+        false
     }
 }

--- a/migrant_lib/src/migrator.rs
+++ b/migrant_lib/src/migrator.rs
@@ -245,8 +245,9 @@ impl Migrator {
         }
 
         // Wrap the migration's SQL and its bookkeeping row in one transaction so
-        // they commit or roll back together (see `Migratable::use_transaction`).
-        let transactional = next.use_transaction();
+        // they commit or roll back together, per direction (see
+        // `Migratable::use_transaction`).
+        let transactional = next.use_transaction(self.direction);
         if transactional {
             config.begin_transaction()?;
         }

--- a/migrant_lib/src/migrator.rs
+++ b/migrant_lib/src/migrator.rs
@@ -9,6 +9,7 @@ use crate::macros::{bail, err};
 use crate::migratable::Migratable;
 use crate::ops;
 use crate::util::print_flush;
+use crate::DbKind;
 
 /// Represents direction to apply migrations.
 /// `Up`   -> up.sql
@@ -40,6 +41,7 @@ pub struct Migrator {
     all: bool,
     show_output: bool,
     swallow_completion: bool,
+    synchronized: bool,
 }
 
 impl Migrator {
@@ -53,6 +55,7 @@ impl Migrator {
             all: false,
             show_output: true,
             swallow_completion: false,
+            synchronized: true,
         }
     }
 
@@ -97,6 +100,23 @@ impl Migrator {
         self
     }
 
+    /// Serialize migration runs across processes using a database advisory lock.
+    /// Default is `true`.
+    ///
+    /// When enabled, a run against a server database (postgres/mysql) takes a
+    /// session-level advisory lock for its whole duration, so concurrent
+    /// migrators -- for example several application instances booting at once --
+    /// apply migrations one at a time instead of racing. The lock is released
+    /// when the run finishes, and automatically by the database if the process
+    /// dies mid-run. Sqlite has no cross-process migration concurrency to guard
+    /// against, so this setting has no effect there.
+    ///
+    /// Disable it only when an outer mechanism already serializes migrations.
+    pub fn synchronized(&mut self, synchronized: bool) -> &mut Self {
+        self.synchronized = synchronized;
+        self
+    }
+
     /// Apply migrations using current configuration
     ///
     /// Returns an `Error::MigrationComplete` if all migrations in the given
@@ -116,6 +136,24 @@ impl Migrator {
     /// Apply migrations until complete (`all`) or a single one has been applied
     fn run(&self) -> Result<()> {
         let mut config = self.config.clone();
+
+        // For server databases, take the migration advisory lock so concurrent
+        // migrators (e.g. several app instances booting at once) serialize
+        // instead of racing. Acquire it *before* re-reading applied state, then
+        // reload under the lock so we observe any migrations a peer committed
+        // while we were waiting and don't re-run them. Sqlite has no such lock
+        // (and no cross-process concurrency), so its path is unchanged.
+        let _lock = if self.synchronized && config.database_type() != DbKind::Sqlite {
+            config.acquire_migration_lock()?;
+            // Guard is created before `reload` so the lock is released even if
+            // the reload fails; the reloaded config shares this connection.
+            let guard = MigrationLock::new(&config);
+            config = config.reload()?;
+            Some(guard)
+        } else {
+            None
+        };
+
         let mut applied_any = false;
         loop {
             match self.apply_next(&config) {
@@ -199,35 +237,75 @@ impl Migrator {
             next.description(&self.direction)
         ));
 
+        let tag = next.tag();
+
         if self.fake {
             self.println("  ✓ (fake)");
-        } else {
-            let res = match self.direction {
-                Direction::Up => next.apply_up(config),
-                Direction::Down => next.apply_down(config),
-            };
-            match res {
-                Ok(_) => self.println("  ✓"),
-                Err(ref e) => {
-                    self.println("");
-                    if self.force {
-                        self.println(&format!(
-                            " ** Error ** (Continuing because `--force` flag was specified)\n ** {}",
-                            e
-                        ));
-                    } else {
-                        bail!(Migration, "Migration was unsucessful...\n{}", e);
-                    }
+            return self.record_tag(config, &tag);
+        }
+
+        // Wrap the migration's SQL and its bookkeeping row in one transaction so
+        // they commit or roll back together (see `Migratable::use_transaction`).
+        let transactional = next.use_transaction();
+        if transactional {
+            config.begin_transaction()?;
+        }
+
+        match self.apply_and_record(config, next, &tag) {
+            Ok(()) => {
+                if transactional {
+                    config.commit_transaction()?;
+                }
+                self.println("  ✓");
+                Ok(())
+            }
+            Err(msg) => {
+                if transactional {
+                    // `with_conn` already rolled the connection back in place on
+                    // the error (preserving the session and its advisory lock);
+                    // this explicit rollback is a harmless best-effort backstop.
+                    config.rollback_transaction();
+                }
+                self.println("");
+                if self.force {
+                    self.println(&format!(
+                        " ** Error ** (Continuing because `--force` flag was specified)\n ** {}",
+                        msg
+                    ));
+                    // Legacy `force` behavior: record the tag anyway. The
+                    // transaction (if any) was rolled back, so this stands alone.
+                    self.record_tag(config, &tag)
+                } else {
+                    bail!(Migration, "Migration was unsucessful...\n{}", msg)
                 }
             }
         }
+    }
 
-        let tag = next.tag();
+    /// Apply the migration in the current direction and record its bookkeeping
+    /// row. Runs inside the caller's transaction (when one is active) so the two
+    /// are atomic. Returns the failure's display string on error.
+    fn apply_and_record(
+        &self,
+        config: &Config,
+        next: &dyn Migratable,
+        tag: &str,
+    ) -> std::result::Result<(), String> {
         match self.direction {
-            Direction::Up => config.insert_migration_tag(&tag)?,
-            Direction::Down => config.delete_migration_tag(&tag)?,
+            Direction::Up => next.apply_up(config),
+            Direction::Down => next.apply_down(config),
         }
-        Ok(())
+        .map_err(|e| e.to_string())?;
+        self.record_tag(config, tag).map_err(|e| e.to_string())
+    }
+
+    /// Record the migration as applied (`Up`) or un-applied (`Down`) in the
+    /// `__migrant_migrations` table.
+    fn record_tag(&self, config: &Config, tag: &str) -> Result<()> {
+        match self.direction {
+            Direction::Up => config.insert_migration_tag(tag),
+            Direction::Down => config.delete_migration_tag(tag),
+        }
     }
 
     fn print(&self, s: &str) {
@@ -240,6 +318,28 @@ impl Migrator {
         if self.show_output {
             println!("{}", s);
         }
+    }
+}
+
+/// RAII guard that releases the migration advisory lock when dropped, so the
+/// lock is freed on every exit path from a synchronized run (success, an early
+/// `?` error, or a panic). Holds a `Config` clone, which shares the same live
+/// connection the lock was taken on.
+struct MigrationLock {
+    config: Config,
+}
+
+impl MigrationLock {
+    fn new(config: &Config) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+}
+
+impl Drop for MigrationLock {
+    fn drop(&mut self) {
+        self.config.release_migration_lock();
     }
 }
 

--- a/migrant_lib/src/ops.rs
+++ b/migrant_lib/src/ops.rs
@@ -110,6 +110,7 @@ pub(crate) fn search_for_migrations(mig_root: &Path) -> Result<Vec<FileMigration
             down,
             tag: tag.to_owned(),
             stamp: Some(stamp),
+            no_transaction: false,
         });
     }
 

--- a/migrant_lib/tests/server_dbs.rs
+++ b/migrant_lib/tests/server_dbs.rs
@@ -26,8 +26,8 @@ fn parse_conn_str(conn_str: &str, default_port: u16) -> ConnParts {
     }
 }
 
-fn apply_and_unapply(settings: Settings) {
-    let mut config = Config::with_settings(&settings);
+fn apply_and_unapply(settings: &Settings) {
+    let mut config = Config::with_settings(settings);
     config.setup().unwrap();
     config
         .use_migrations(&[
@@ -117,8 +117,114 @@ fn postgres_end_to_end() {
         .unwrap();
     // drop any leftover table from an earlier interrupted run
     drop_pg_migration_table(&conn_str);
-    apply_and_unapply(settings);
+    apply_and_unapply(&settings);
     drop_pg_migration_table(&conn_str);
+    // atomic-rollback phase runs against the same database (see the helper doc)
+    assert_failed_migration_rolls_back(&conn_str, &settings);
+    drop_pg_migration_table(&conn_str);
+    // force-past-failure phase, also against the same database
+    assert_force_continues_holding_lock(&conn_str, &settings);
+    drop_pg_migration_table(&conn_str);
+}
+
+/// A migration whose SQL fails partway is rolled back atomically on postgres:
+/// the partial DDL is undone and the bookkeeping row is never written.
+///
+/// Not a standalone `#[test]`: it shares the one postgres database (and the
+/// single `__migrant_migrations` table) with `postgres_end_to_end`, so it runs
+/// as a phase of that test rather than racing it under cargo's parallel runner.
+#[cfg(feature = "d-postgres")]
+fn assert_failed_migration_rolls_back(conn_str: &str, settings: &Settings) {
+    let mut client = postgres::Client::connect(conn_str, postgres::NoTls).unwrap();
+    client.batch_execute("drop table if exists good;").unwrap();
+
+    let mut config = Config::with_settings(settings);
+    config
+        .use_migrations(&[EmbeddedMigration::with_tag("bad")
+            .up("create table good (x integer); insert into does_not_exist values (1);")
+            .down("drop table good;")
+            .boxed()])
+        .unwrap();
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(res.is_err(), "a migration with invalid sql must fail");
+
+    let good_exists: bool = client
+        .query_one(
+            "select exists(select 1 from pg_tables where tablename = 'good')",
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert!(!good_exists, "partial DDL must be rolled back");
+
+    let config = config.reload().unwrap();
+    let statuses = migrant_lib::migration_statuses(&config).unwrap();
+    assert!(
+        statuses.iter().all(|m| !m.applied),
+        "the tag must not be recorded when the migration fails"
+    );
+
+    client.batch_execute("drop table if exists good;").unwrap();
+}
+
+/// A `force`d run continues past a failed migration and applies the rest on the
+/// same locked session (the connection is recovered in place on the error, so
+/// the advisory lock is never released mid-run). Shares the postgres database
+/// with `postgres_end_to_end`, so it runs as one of its phases.
+#[cfg(feature = "d-postgres")]
+fn assert_force_continues_holding_lock(conn_str: &str, settings: &Settings) {
+    let mut client = postgres::Client::connect(conn_str, postgres::NoTls).unwrap();
+    client.batch_execute("drop table if exists later;").unwrap();
+
+    let mut config = Config::with_settings(settings);
+    config
+        .use_migrations(&[
+            EmbeddedMigration::with_tag("bad")
+                .up("insert into does_not_exist values (1);")
+                .down("select 1;")
+                .boxed(),
+            EmbeddedMigration::with_tag("later")
+                .up("create table later (x integer);")
+                .down("drop table later;")
+                .boxed(),
+        ])
+        .unwrap();
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    // force past the failing first migration; the run must continue and apply
+    // the second on the same session that still holds the advisory lock.
+    Migrator::with_config(&config)
+        .all(true)
+        .force(true)
+        .show_output(false)
+        .swallow_completion(true)
+        .apply()
+        .unwrap();
+
+    let later_exists: bool = client
+        .query_one(
+            "select exists(select 1 from pg_tables where tablename = 'later')",
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        later_exists,
+        "force must continue past the failure and apply later migrations"
+    );
+
+    let config = config.reload().unwrap();
+    let statuses = migrant_lib::migration_statuses(&config).unwrap();
+    assert!(
+        statuses.iter().all(|m| m.applied),
+        "force records every migration as applied, including the failed one"
+    );
+
+    client.batch_execute("drop table if exists later;").unwrap();
 }
 
 #[cfg(feature = "d-mysql")]
@@ -142,6 +248,6 @@ fn mysql_end_to_end() {
         .unwrap();
     // drop any leftover table from an earlier interrupted run
     drop_mysql_migration_table(&conn_str);
-    apply_and_unapply(settings);
+    apply_and_unapply(&settings);
     drop_mysql_migration_table(&conn_str);
 }

--- a/migrant_lib/tests/sqlite.rs
+++ b/migrant_lib/tests/sqlite.rs
@@ -3,7 +3,8 @@
 #![cfg(feature = "d-sqlite")]
 
 use migrant_lib::{
-    Config, ConnConfig, Direction, EmbeddedMigration, FnMigration, Migrator, Settings,
+    Config, ConnConfig, Direction, EmbeddedMigration, FileMigration, FnMigration, Migrator,
+    Settings,
 };
 
 fn seed_users(conn: ConnConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -179,6 +180,108 @@ fn no_transaction_migration_leaves_partial_state() {
         applied_tags(&config).is_empty(),
         "the tag must not be recorded when the migration fails"
     );
+}
+
+#[test]
+fn embedded_directive_opts_up_out_of_transaction() {
+    // `up` carries the `-- migrant:no-transaction` directive and fails partway.
+    // Without a wrapping transaction the earlier `create table` persists,
+    // proving the directive was read from the embedded up SQL.
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let mut config = Config::with_settings(&settings);
+    config
+        .use_migrations(&[EmbeddedMigration::with_tag("bad-up")
+            .up("-- migrant:no-transaction\ncreate table up_good (x integer); insert into nope values (1);")
+            .down("select 1;")
+            .boxed()])
+        .unwrap();
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(res.is_err(), "a migration with invalid sql must fail");
+
+    let config = config.reload().unwrap();
+    assert!(
+        table_exists(&config, "up_good"),
+        "the directive up must run without a transaction, leaving the partial create"
+    );
+    assert!(applied_tags(&config).is_empty());
+}
+
+#[test]
+fn directive_applies_per_direction() {
+    // `up` has no directive (transactional); `down` carries the directive
+    // (non-transactional). Applying up succeeds; a failing down then leaves its
+    // partial state behind, demonstrating the flag is resolved per direction.
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let mut config = Config::with_settings(&settings);
+    config
+        .use_migrations(&[EmbeddedMigration::with_tag("thing")
+            .up("create table thing (x integer);")
+            .down("-- migrant:no-transaction\ncreate table down_good (x integer); insert into nope values (1);")
+            .boxed()])
+        .unwrap();
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    Migrator::with_config(&config)
+        .show_output(false)
+        .swallow_completion(true)
+        .apply()
+        .unwrap();
+    let config = config.reload().unwrap();
+    assert_eq!(vec!["thing".to_string()], applied_tags(&config));
+
+    let res = Migrator::with_config(&config)
+        .direction(Direction::Down)
+        .show_output(false)
+        .apply();
+    assert!(res.is_err(), "the failing down migration must error");
+
+    let config = config.reload().unwrap();
+    assert!(
+        table_exists(&config, "down_good"),
+        "the directive down must run without a transaction, leaving the partial create"
+    );
+}
+
+#[test]
+fn file_migration_reads_no_transaction_directive() {
+    // The `migrant` CLI discovers file migrations, so the directive must be read
+    // from the up.sql on disk (not only from an in-code builder call).
+    let dir = tempfile::tempdir().unwrap();
+    let up = dir.path().join("up.sql");
+    let down = dir.path().join("down.sql");
+    std::fs::write(
+        &up,
+        "-- migrant:no-transaction\ncreate table up_good (x integer); insert into nope values (1);",
+    )
+    .unwrap();
+    std::fs::write(&down, "select 1;").unwrap();
+
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let mut config = Config::with_settings(&settings);
+    config
+        .use_migrations(&[FileMigration::with_tag("filed")
+            .up(&up)
+            .unwrap()
+            .down(&down)
+            .unwrap()
+            .boxed()])
+        .unwrap();
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(res.is_err(), "a migration with invalid sql must fail");
+
+    let config = config.reload().unwrap();
+    assert!(
+        table_exists(&config, "up_good"),
+        "the file directive must opt the up out of a transaction"
+    );
+    assert!(applied_tags(&config).is_empty());
 }
 
 #[test]

--- a/migrant_lib/tests/sqlite.rs
+++ b/migrant_lib/tests/sqlite.rs
@@ -53,6 +53,33 @@ fn applied_tags(config: &Config) -> Vec<String> {
         .collect()
 }
 
+fn table_exists(config: &Config, name: &str) -> bool {
+    let handle = config.sqlite_connection().unwrap();
+    let conn = handle.lock().unwrap();
+    conn.query_row(
+        "select exists(select 1 from sqlite_master where type = 'table' and name = ?1)",
+        [name],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+/// Build an in-memory config with a single migration whose `up` creates a table
+/// and then runs an invalid statement, so application fails partway through.
+fn failing_migration_config(no_transaction: bool) -> Config {
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let mut migration = EmbeddedMigration::with_tag("bad");
+    migration
+        .up("create table good (x integer); insert into does_not_exist values (1);")
+        .down("drop table good;");
+    if no_transaction {
+        migration.no_transaction();
+    }
+    let mut config = Config::with_settings(&settings);
+    config.use_migrations(&[migration.boxed()]).unwrap();
+    config
+}
+
 #[test]
 fn in_memory_database_end_to_end() {
     let settings = Settings::configure_sqlite().memory().build().unwrap();
@@ -108,6 +135,50 @@ fn in_memory_database_shared_across_clones() {
         .query_row("select count(*) from t", [], |row| row.get(0))
         .unwrap();
     assert_eq!(1, n, "clones share the same in-memory database");
+}
+
+#[test]
+fn failed_migration_rolls_back_atomically() {
+    let config = failing_migration_config(false);
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(res.is_err(), "a migration with invalid sql must fail");
+
+    let config = config.reload().unwrap();
+    // The whole migration was wrapped in a transaction: the partial `create
+    // table` is rolled back and the bookkeeping row is never written.
+    assert!(
+        !table_exists(&config, "good"),
+        "partial DDL must be rolled back"
+    );
+    assert!(
+        applied_tags(&config).is_empty(),
+        "the tag must not be recorded when the migration fails"
+    );
+}
+
+#[test]
+fn no_transaction_migration_leaves_partial_state() {
+    let config = failing_migration_config(true);
+    config.setup().unwrap();
+    let config = config.reload().unwrap();
+
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(res.is_err(), "a migration with invalid sql must fail");
+
+    let config = config.reload().unwrap();
+    // With `no_transaction`, the earlier `create table` is not rolled back...
+    assert!(
+        table_exists(&config, "good"),
+        "without a transaction the create persists"
+    );
+    // ...but a failed migration is still never recorded as applied.
+    assert!(
+        applied_tags(&config).is_empty(),
+        "the tag must not be recorded when the migration fails"
+    );
 }
 
 #[test]

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,6 +19,8 @@ can be built). Keep each row's status current with `spec.py set`.
 | Library Config API | done | [library-config-api.md](library-config-api.md) |
 | Migration Types | done | [migration-types.md](migration-types.md) |
 | Migrator API | done | [migrator-api.md](migrator-api.md) |
+| Transactional Migrations | done | [transactional-migrations.md](transactional-migrations.md) |
+| Advisory Locking | done | [advisory-locking.md](advisory-locking.md) |
 | Settings Builders | done | [settings-builders.md](settings-builders.md) |
 | In-Memory SQLite | done | [in-memory-sqlite.md](in-memory-sqlite.md) |
 | Database Backends | done | [database-backends.md](database-backends.md) |

--- a/spec/advisory-locking.md
+++ b/spec/advisory-locking.md
@@ -1,0 +1,43 @@
+# Advisory Locking
+
+Migration runs serialize across processes using a database advisory lock.
+
+## LOCK-1
+
+`Migrator::synchronized(bool)` (default `true`) makes a run take a database
+advisory lock for its whole duration, so concurrent migrators -- for example
+several application instances booting at once -- apply migrations one at a time
+instead of racing.
+
+## LOCK-2
+
+For server databases the lock is session-level and held on the run's live
+connection: Postgres `pg_advisory_lock`, MySQL `GET_LOCK` (blocking until the
+lock is available). It is released when the run finishes, and automatically by
+the database if the connection (session) drops mid-run, so a crashed migrator
+cannot leave a stuck lock.
+
+## LOCK-3
+
+The lock is acquired before applied migrations are re-read, so a run that waited
+for a peer observes the peer's committed migrations under the lock and does not
+re-apply them.
+
+## LOCK-4
+
+Sqlite has no advisory lock and no cross-process migration concurrency (a single
+connection already serializes writers), so `synchronized` is a no-op there.
+
+## LOCK-5
+
+A mid-run error recovers the run's connection in place (a rollback) rather than
+dropping it, so the session -- and the advisory lock it holds -- is not released
+mid-run. A `force`d run therefore keeps holding the lock as it continues past a
+failed migration, with no window for another migrator to interleave. Only a
+genuinely dead connection (its rollback also fails) is dropped.
+
+Coverage: `migrant_lib/src/drivers/pg.rs`, `mysql.rs` (`advisory_lock`,
+`advisory_lock_is_exclusive`, gated on the test connection strings and run via
+`test.sh`); the `advisory_lock` test also covers lock survival across an
+in-transaction error; end-to-end apply/unapply and the `force`-past-failure
+phase through the synchronized path in `migrant_lib/tests/server_dbs.rs`.

--- a/spec/migration-types.md
+++ b/spec/migration-types.md
@@ -21,4 +21,11 @@ so binaries need no migration files on disk.
 `Config::use_migrations(&[...])` registers an explicit, ordered migration list;
 `is_explicit()` reports whether explicit migrations are in use (vs file discovery).
 
+## MIGTYPE-5
+
+`Migratable::use_transaction()` reports whether a migration is applied inside a
+transaction (default `true`). `EmbeddedMigration` and `FileMigration` expose
+`no_transaction()` to opt out; `FnMigration` never runs in a migrator-managed
+transaction. See [transactional-migrations.md](transactional-migrations.md).
+
 Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`.

--- a/spec/migration-types.md
+++ b/spec/migration-types.md
@@ -23,9 +23,12 @@ so binaries need no migration files on disk.
 
 ## MIGTYPE-5
 
-`Migratable::use_transaction()` reports whether a migration is applied inside a
-transaction (default `true`). `EmbeddedMigration` and `FileMigration` expose
-`no_transaction()` to opt out; `FnMigration` never runs in a migrator-managed
-transaction. See [transactional-migrations.md](transactional-migrations.md).
+`Migratable::use_transaction(direction)` reports whether a migration is applied
+inside a transaction for that direction (default `true`). `EmbeddedMigration` and
+`FileMigration` expose `no_transaction()` to opt out via the builder, or a
+`-- migrant:no-transaction` directive in a direction's SQL to opt that direction
+out (the directive takes precedence); `FnMigration` never runs in a
+migrator-managed transaction. See
+[transactional-migrations.md](transactional-migrations.md).
 
 Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`.

--- a/spec/migrator-api.md
+++ b/spec/migrator-api.md
@@ -22,5 +22,12 @@ without executing migration SQL.
 `show_output(bool)` toggles progress output; `swallow_completion(bool)` converts the
 `MigrationComplete` error into `Ok` so "nothing to apply" is not an error.
 
+## MIGRATOR-5
+
+`synchronized(bool)` (default `true`) serializes migration runs across processes with a
+database advisory lock, and each migration is applied in a transaction with its bookkeeping
+row. See [advisory-locking.md](advisory-locking.md) and
+[transactional-migrations.md](transactional-migrations.md).
+
 Coverage: `migrant_lib/tests/sqlite.rs`, `server_dbs.rs`, `reload_memory.rs`,
 `tests/migrant.rs`; unit tests in `migrant_lib/src/migrator.rs`.

--- a/spec/transactional-migrations.md
+++ b/spec/transactional-migrations.md
@@ -1,0 +1,38 @@
+# Transactional Migrations
+
+Each migration's SQL and its bookkeeping row are applied atomically, with a
+per-migration opt-out.
+
+## TXN-1
+
+By default the migrator wraps a migration's application and its bookkeeping row
+(the insert/delete in `__migrant_migrations`) in a single database transaction,
+so the schema change and the record that it was applied commit or roll back
+together. A migration that fails partway leaves neither partial state nor a
+bookkeeping row.
+
+## TXN-2
+
+`Migratable::use_transaction()` controls wrapping (default `true`).
+`EmbeddedMigration` and `FileMigration` expose `no_transaction()` to opt a
+single migration out -- required for statements a backend refuses to run inside
+a transaction block, such as Postgres `CREATE INDEX CONCURRENTLY`. `FnMigration`
+is never wrapped: it runs arbitrary code that may use its own connection, so it
+returns `false`.
+
+## TXN-3
+
+Migration SQL must not contain its own `begin`/`commit`; the migrator manages
+the transaction. Migrations needing to control transactions themselves opt out
+with `no_transaction()`.
+
+## TXN-4
+
+Backend behavior differs. Sqlite and Postgres roll DDL back, so wrapping makes
+both DDL and DML migrations atomic. MySQL/MariaDB commit DDL implicitly, so
+wrapping only makes pure-DML migrations atomic there; DDL cannot be rolled back
+regardless of this setting.
+
+Coverage: `migrant_lib/tests/sqlite.rs`
+(`failed_migration_rolls_back_atomically`, `no_transaction_migration_leaves_partial_state`);
+`server_dbs.rs` (`postgres_end_to_end` atomic-rollback phase, run via `test.sh`).

--- a/spec/transactional-migrations.md
+++ b/spec/transactional-migrations.md
@@ -13,18 +13,30 @@ bookkeeping row.
 
 ## TXN-2
 
-`Migratable::use_transaction()` controls wrapping (default `true`).
-`EmbeddedMigration` and `FileMigration` expose `no_transaction()` to opt a
-single migration out -- required for statements a backend refuses to run inside
-a transaction block, such as Postgres `CREATE INDEX CONCURRENTLY`. `FnMigration`
-is never wrapped: it runs arbitrary code that may use its own connection, so it
-returns `false`.
+`Migratable::use_transaction(direction)` controls wrapping per direction
+(default `true`). `EmbeddedMigration` and `FileMigration` expose
+`no_transaction()` to opt both directions out via the builder -- required for
+statements a backend refuses to run inside a transaction block, such as Postgres
+`CREATE INDEX CONCURRENTLY` or `ALTER TYPE ... ADD VALUE`. `FnMigration` is never
+wrapped: it runs arbitrary code that may use its own connection, so it returns
+`false`.
 
 ## TXN-3
 
 Migration SQL must not contain its own `begin`/`commit`; the migrator manages
 the transaction. Migrations needing to control transactions themselves opt out
-with `no_transaction()`.
+with `no_transaction()` or the `-- migrant:no-transaction` directive (TXN-5).
+
+## TXN-5
+
+A `-- migrant:no-transaction` directive on a `--` comment line in a direction's
+SQL opts that direction out of wrapping. It is resolved per direction and per
+source: an `up.sql`/`down.sql` file for `FileMigration` (read at apply time),
+the embedded string for `EmbeddedMigration`. A directive in the SQL takes
+precedence over the builder-level `no_transaction()` flag, so file migrations
+discovered by the `migrant` CLI can opt a direction out with no Rust code. The
+directive is matched case-insensitively as the first token of the comment, so a
+trailing explanation (`-- migrant:no-transaction (enum add)`) is allowed.
 
 ## TXN-4
 


### PR DESCRIPTION
Serialize concurrent migration runs and make each migration atomic.

## Advisory locking
- Add `Migrator::synchronized` (default on): hold a session-level advisory lock for the whole run (postgres `pg_advisory_lock`, mysql `GET_LOCK`), released at the end and automatically by the database if the connection drops. No-op on sqlite.
- Re-read applied migrations after taking the lock, so a run that waited for a peer observes the peer's committed migrations and does not re-apply them.
- Recover a server connection in place with a rollback on error instead of dropping it, so the session (and its lock) survives a mid-run error and a `force`d run keeps holding the lock as it continues past a failure.

## Transactional migrations
- Wrap each migration's SQL and its `__migrant_migrations` bookkeeping row in a single transaction by default, so a failed migration leaves no partial state or record.
- Add `no_transaction()` on `EmbeddedMigration`/`FileMigration` and `Migratable::use_transaction` to opt out (e.g. postgres `CREATE INDEX CONCURRENTLY`); `FnMigration` is never wrapped.
- Migration SQL should no longer include its own `begin`/`commit`. Note that MySQL/MariaDB commit DDL implicitly, so wrapping only makes pure-DML migrations atomic there.

## Docs and tests
- Add spec docs `advisory-locking.md` and `transactional-migrations.md`; cross-reference from `migrator-api.md` and `migration-types.md`.
- sqlite atomicity and `no_transaction` opt-out tests (always run); postgres/mysql advisory-lock exclusivity, lock-survives-error, atomic-rollback, and force-past-failure tests run via `migrant_lib/test.sh` against throwaway docker databases.

Not included: a `migrant_lib` version bump (currently 0.35), left as a release decision.
