### PR TITLE
add force modes, auto-refresh applied state, abort synchronized runs on a lost lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- `--force` takes an optional mode: bare `--force` (or `--force=accept-failures`) records a
+  failed migration as applied and continues; `--force=skip-failures` continues without
+  recording it, so the next run retries it
+- `migrant shell` falls back to the classic `mysql` client when `mysqlsh` is not on `PATH`
+- `database_port` in `Migrant.toml` accepts a TOML integer or a string
+
+### Changed
+- Running any subcommand other than `init` without a `Migrant.toml` now errors with a
+  pointer to `migrant init`, instead of starting the interactive config-creation flow
+- `apply`/`redo` no longer need a manual reload before running: the migrator re-reads
+  applied state itself (see migrant_lib changelog)
+
 ## [0.15.0]
 ### Added
 - `migrant tui` subcommand: interactive terminal UI for viewing and applying migrations

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -36,12 +36,15 @@ run from anywhere inside the project; migrant searches upward for the config.
 `migrant list`
 : List available migrations and mark those applied.
 
-`migrant apply [--down] [--all] [--force] [--fake]`
+`migrant apply [--down] [--all] [--force[=<mode>]] [--fake]`
 : Apply the next migration. `--down` reverts instead of applying. `--all` runs
-  every remaining migration in the chosen direction. `--force` continues past
-  errors. `--fake` records the migration as (un)applied without running its SQL.
+  every remaining migration in the chosen direction. `--force` continues past a
+  failed migration: bare `--force` (or `--force=accept-failures`) records the
+  failed migration as applied anyway, so it is not retried on later runs;
+  `--force=skip-failures` leaves it unrecorded and retries it on the next run.
+  `--fake` records the migration as (un)applied without running its SQL.
 
-`migrant redo [--all] [--force]`
+`migrant redo [--all] [--force[=<mode>]]`
 : Shortcut for the latest `down` then `up`. Useful while iterating on a migration
   you are still writing.
 
@@ -49,8 +52,9 @@ run from anywhere inside the project; migrant searches upward for the config.
 
 `migrant shell`
 : Open a database repl. Requires the matching client on your `PATH`: `sqlite3`
-  for SQLite, `psql` for PostgreSQL, `mysqlsh` for MySQL. The password is passed
-  out of band (`PGPASSWORD`/`MYSQL_PWD`), never on the command line.
+  for SQLite, `psql` for PostgreSQL, and for MySQL `mysqlsh` when installed,
+  falling back to the classic `mysql` client. The password is passed out of band
+  (`PGPASSWORD`/`MYSQL_PWD`), never on the command line.
 
 `migrant tui`
 : Interactive terminal UI for viewing and applying migrations.

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -32,8 +32,9 @@ connection, so the session, and the advisory lock it holds, survives the error. 
 migrator to interleave.
 
 The one case where the lock is unavoidably lost mid-run is a genuinely dead
-connection. If the session ends, the database has already released the lock;
-migrant reconnects and continues, but that new session does not hold it.
+connection: if the session ends, the database has already released the lock. A
+synchronized run detects this and aborts with an error rather than continuing
+unserialized on a new, unlocked session. Re-run migrations to continue.
 
 ## Library control
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -41,7 +41,8 @@ migration_location = "migrations"
 sslmode = "require"
 ```
 
-MySQL uses the same server keys with `database_type = "mysql"`.
+MySQL uses the same server keys with `database_type = "mysql"`. `database_port`
+accepts a TOML integer or a string.
 
 ## Environment variables
 
@@ -54,8 +55,11 @@ database_password = "env:DB_PASSWORD"
 
 `migrant init --default-from-env` seeds every value in this form.
 
-A `.env` file in scope is loaded automatically (via dotenvy) before values are
-resolved, so `env:` references can come from `.env` during local development.
+The `migrant` CLI loads a `.env` file automatically (via dotenvy) before values
+are resolved, so `env:` references can come from `.env` during local
+development. The library does not load `.env`: `Config::from_settings_file`
+resolves `env:` references from the process environment as-is, so load any
+`.env` file yourself before creating the config.
 
 ## Connection strings and SSL
 

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -37,8 +37,8 @@ config.use_migrations(&[
         .boxed(),
 ])?;
 
-// Load applied state, then apply everything.
-let config = config.reload()?;
+// Apply everything. The migrator re-reads applied state from the database
+// itself, so no manual reload is needed before applying.
 Migrator::with_config(&config)
     .all(true)
     .apply()?;
@@ -46,8 +46,10 @@ Migrator::with_config(&config)
 # }
 ```
 
-`reload()` re-reads the applied set from the database and returns a fresh
-`Config`. Call it after `setup`/`use_migrations` and after each apply cycle.
+`Config::reload()` re-reads the applied set from the database and returns a
+fresh `Config`. It is only needed when *your* code inspects applied state (for
+example via `migration_statuses`) after applying; `Migrator::apply` refreshes
+its own view.
 
 ## Settings builders
 
@@ -66,12 +68,16 @@ Or load from a file: `Config::from_settings_file("Migrant.toml")`.
 Migrator::with_config(&config)
     .direction(migrant_lib::Direction::Up) // or Down
     .all(true)          // every remaining migration, not just the next
-    .force(false)       // continue past errors
+    .force(migrant_lib::ForceMode::Off)    // or AcceptFailures / SkipFailures
     .fake(false)        // record without running SQL
     .synchronized(true) // advisory lock for server databases (default)
     .show_output(true)
     .apply()?;
 ```
+
+`ForceMode` controls failed-migration handling: `Off` (default) aborts the run,
+`AcceptFailures` continues and records the failed migration as applied,
+`SkipFailures` continues without recording it so the next run retries it.
 
 `synchronized` controls the advisory lock; see
 [Concurrency and locking](concurrency.md). Transaction wrapping is per migration;

--- a/docs/src/transactions.md
+++ b/docs/src/transactions.md
@@ -79,6 +79,11 @@ in the file stay applied. migrant still does not record the migration as applied
 when it fails, so a re-run will attempt it again. Write opted-out migrations so a
 partial application is safe to retry.
 
+Note that `--force` changes the recording rule: bare `--force`
+(`accept-failures`) records a failed migration as applied anyway, while
+`--force=skip-failures` keeps the not-recorded/retry behavior described above.
+See [the apply flags](cli.md).
+
 ## Interaction with locking
 
 Transaction wrapping is independent of the migration advisory lock. The lock

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -41,8 +41,9 @@ or add the `update` feature.
 
 ## `migrant shell` cannot find the client
 
-`shell` runs the database's own client: `sqlite3`, `psql`, or `mysqlsh`. Install
-the matching client and make sure it is on your `PATH`.
+`shell` runs the database's own client: `sqlite3`, `psql`, or for mysql
+`mysqlsh` when installed and the classic `mysql` client otherwise. Install a
+matching client and make sure it is on your `PATH`.
 
 ## Wrong config is picked up
 

--- a/migrant_lib/CHANGELOG.md
+++ b/migrant_lib/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## [Unreleased]
 ### Added
+- `ForceMode` (`Off`/`AcceptFailures`/`SkipFailures`) controls how a run handles a failed
+  migration: `AcceptFailures` records it as applied anyway, `SkipFailures` continues without
+  recording so the next run retries it. Parses from `off`/`accept-failures`/`skip-failures`
+- `env:VAR` resolution now also covers `ssl_cert_file` and `database_params` keys
+- `database_port` in `Migrant.toml` accepts a TOML integer or a string
+- `shell` falls back to the classic `mysql` client when `mysqlsh` is not on `PATH`
+
 ### Changed
+- `Migrator::force` takes a `ForceMode` instead of a `bool`
+- `Migrator::apply` re-reads applied state from the database itself (all backends), so a
+  manual `Config::reload` before applying is no longer needed. The re-read stays on the
+  run's own connection and never re-reads the settings file
+- A synchronized run aborts with an error if its connection dies and is re-established
+  mid-run, instead of continuing without the advisory lock
+
 ### Removed
 
 ## [0.35.0]

--- a/migrant_lib/src/config/mod.rs
+++ b/migrant_lib/src/config/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 
 use log::{debug, error};
@@ -40,6 +41,13 @@ pub struct Config {
     pub(crate) migrations: Option<Vec<Box<dyn Migratable>>>,
     pub(crate) cli_compatible: bool,
     conn: Arc<Mutex<Option<DbConnection>>>,
+    /// Bumped whenever an established connection is dropped (and will be
+    /// re-established on next use). Session-scoped state -- notably the
+    /// migration advisory lock -- does not survive such a drop, so the
+    /// migrator uses this to detect a lost lock mid-run. Shared with the
+    /// connection itself: clones and reloads that carry the connection over
+    /// carry the generation with it.
+    conn_generation: Arc<AtomicU64>,
 }
 
 impl Config {
@@ -51,6 +59,7 @@ impl Config {
             migrations: None,
             cli_compatible: false,
             conn: Arc::new(Mutex::new(None)),
+            conn_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -113,9 +122,16 @@ impl Config {
             // rollback and an in-memory database would be lost if dropped.
             if conn.rollback().is_err() {
                 *guard = None;
+                self.conn_generation.fetch_add(1, Ordering::SeqCst);
             }
         }
         res
+    }
+
+    /// Generation of the current connection. Changes whenever an established
+    /// connection had to be dropped (see `conn_generation`).
+    pub(crate) fn connection_generation(&self) -> u64 {
+        self.conn_generation.load(Ordering::SeqCst)
     }
 
     /// Execute a batch of sql statements on the database
@@ -357,6 +373,7 @@ impl Config {
                 // reloaded config connects using the new settings.
                 if reloaded.settings == self.settings {
                     reloaded.conn = Arc::clone(&self.conn);
+                    reloaded.conn_generation = Arc::clone(&self.conn_generation);
                 }
                 reloaded
             }
@@ -366,6 +383,15 @@ impl Config {
         config.migrations = self.migrations.clone();
         config.applied = config.load_applied()?;
         Ok(config)
+    }
+
+    /// Re-read applied migrations from the database in place, without
+    /// re-reading the settings file or touching the live connection (unlike
+    /// `Config::reload`). Used by the migrator so a run stays on the
+    /// connection its advisory lock was acquired on.
+    pub(crate) fn refresh_applied(&mut self) -> Result<()> {
+        self.applied = self.load_applied()?;
+        Ok(())
     }
 
     /// Load the applied migrations from the database migration table

--- a/migrant_lib/src/config/settings.rs
+++ b/migrant_lib/src/config/settings.rs
@@ -37,6 +37,38 @@ fn resolve_env_opt(value: &Option<String>) -> Result<Option<String>> {
     value.as_deref().map(resolve_env).transpose()
 }
 
+fn resolve_env_path_opt(value: &Option<PathBuf>) -> Result<Option<PathBuf>> {
+    value
+        .as_deref()
+        .map(|path| {
+            let s = path
+                .to_str()
+                .ok_or_else(|| err!(Config, "Invalid utf8 path in settings: {:?}", path))?;
+            Ok(PathBuf::from(resolve_env(s)?))
+        })
+        .transpose()
+}
+
+/// Deserialize an optional port from either a TOML integer or a string,
+/// so both `database_port = 5432` and `database_port = "5432"` work.
+fn de_port_opt<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Port {
+        Int(u64),
+        Str(String),
+    }
+    Ok(
+        Option::<Port>::deserialize(deserializer)?.map(|port| match port {
+            Port::Int(n) => n.to_string(),
+            Port::Str(s) => s,
+        }),
+    )
+}
+
 /// Sqlite connection settings
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub(crate) struct SqliteSettings {
@@ -64,6 +96,7 @@ pub(crate) struct ServerSettings {
     pub(crate) database_user: String,
     pub(crate) database_password: String,
     pub(crate) database_host: Option<String>,
+    #[serde(default, deserialize_with = "de_port_opt")]
     pub(crate) database_port: Option<String>,
     pub(crate) database_params: Option<BTreeMap<String, String>>,
     pub(crate) ssl_cert_file: Option<PathBuf>,
@@ -71,16 +104,26 @@ pub(crate) struct ServerSettings {
 }
 
 impl ServerSettings {
+    /// The configured host, or `localhost` when unset/empty
+    pub(crate) fn host_or_default(&self) -> String {
+        match self.database_host.as_deref() {
+            Some(host) if !host.is_empty() => host.to_string(),
+            _ => "localhost".to_string(),
+        }
+    }
+
+    /// The configured port, or the given backend default when unset/empty
+    pub(crate) fn port_or_default(&self, default_port: &str) -> String {
+        match self.database_port.as_deref() {
+            Some(port) if !port.is_empty() => port.to_string(),
+            _ => default_port.to_string(),
+        }
+    }
+
     /// Build a `<scheme>://user:pass@host:port/db_name?params` url
     pub(crate) fn connect_string(&self, scheme: &str, default_port: &str) -> Result<String> {
-        let non_empty_or = |val: &Option<String>, default: &str| -> String {
-            match val.as_deref() {
-                Some(v) if !v.is_empty() => v.to_string(),
-                _ => default.to_string(),
-            }
-        };
-        let host = encode(&non_empty_or(&self.database_host, "localhost"));
-        let port = encode(&non_empty_or(&self.database_port, default_port));
+        let host = encode(&self.host_or_default());
+        let port = encode(&self.port_or_default(default_port));
 
         let s = format!(
             "{scheme}://{user}:{pass}@{host}:{port}/{db_name}",
@@ -110,7 +153,7 @@ impl ServerSettings {
             Some(params) => {
                 let mut resolved = BTreeMap::new();
                 for (k, v) in params {
-                    resolved.insert(k.clone(), resolve_env(v)?);
+                    resolved.insert(resolve_env(k)?, resolve_env(v)?);
                 }
                 Some(resolved)
             }
@@ -123,7 +166,7 @@ impl ServerSettings {
             database_host: resolve_env_opt(&self.database_host)?,
             database_port: resolve_env_opt(&self.database_port)?,
             database_params,
-            ssl_cert_file: self.ssl_cert_file.clone(),
+            ssl_cert_file: resolve_env_path_opt(&self.ssl_cert_file)?,
             migration_location: resolve_env_opt(&self.migration_location)?,
         })
     }
@@ -292,6 +335,49 @@ mod tests {
             url,
             "postgres://user%20name:p%40ss%3Aword@my%20host:5432/mydb"
         );
+    }
+
+    #[test]
+    fn database_port_deserializes_from_integer_or_string() {
+        // The book's example config uses a bare TOML integer; both forms must work.
+        #[derive(Deserialize)]
+        struct Probe {
+            #[serde(default, deserialize_with = "de_port_opt")]
+            database_port: Option<String>,
+        }
+        let int_form: Probe = toml::from_str("database_port = 5432").unwrap();
+        assert_eq!(int_form.database_port.as_deref(), Some("5432"));
+        let str_form: Probe = toml::from_str("database_port = \"5432\"").unwrap();
+        assert_eq!(str_form.database_port.as_deref(), Some("5432"));
+        let absent: Probe = toml::from_str("").unwrap();
+        assert_eq!(absent.database_port, None);
+    }
+
+    #[test]
+    fn resolve_env_vars_covers_ssl_cert_file_and_param_keys() {
+        let cert_var = "MIGRANT_TEST_SSL_CERT_FILE_5D2B91";
+        let key_var = "MIGRANT_TEST_PARAM_KEY_5D2B91";
+        env::set_var(cert_var, "/certs/db.pem");
+        env::set_var(key_var, "sslmode");
+
+        let mut settings = server_settings();
+        settings.ssl_cert_file = Some(PathBuf::from(format!("env:{}", cert_var)));
+        let mut params = BTreeMap::new();
+        params.insert(format!("env:{}", key_var), "require".to_string());
+        settings.database_params = Some(params);
+
+        let resolved = settings.resolve_env_vars().unwrap();
+        assert_eq!(
+            resolved.ssl_cert_file.as_deref(),
+            Some(Path::new("/certs/db.pem"))
+        );
+        assert_eq!(
+            resolved.database_params.unwrap().get("sslmode"),
+            Some(&"require".to_string())
+        );
+
+        env::remove_var(cert_var);
+        env::remove_var(key_var);
     }
 
     #[test]

--- a/migrant_lib/src/drivers/mysql.rs
+++ b/migrant_lib/src/drivers/mysql.rs
@@ -158,11 +158,12 @@ mod tests {
             .unwrap();
     }
 
-    /// The advisory lock is exclusive across connections: while one session
-    /// holds it, another cannot, and it becomes available again once released.
+    /// Advisory-lock behavior. The two scenarios share the one fixed lock
+    /// name, so they run sequentially inside a single `#[test]` rather than
+    /// racing each other under cargo's parallel runner.
     /// Requires a running mysql instance (`MYSQL_TEST_CONN_STR`).
     #[test]
-    fn advisory_lock_is_exclusive() {
+    fn advisory_lock() {
         let conn_str = match std::env::var("MYSQL_TEST_CONN_STR") {
             Ok(s) => s,
             Err(_) => {
@@ -170,16 +171,23 @@ mod tests {
                 return;
             }
         };
-        let mut holder = MySqlConn::connect(&conn_str).unwrap();
-        let mut other = MySqlConn::connect(&conn_str).unwrap();
+        lock_is_exclusive(&conn_str);
+        lock_survives_in_transaction_error(&conn_str);
+    }
 
-        // `get_lock` with a zero timeout returns immediately: 1 got it, 0 timed out.
-        let try_lock = |c: &mut MySqlConn| -> Option<i64> {
-            c.conn
-                .query_first(format!("select get_lock('{}', 0)", ADVISORY_LOCK_NAME))
-                .unwrap()
-                .flatten()
-        };
+    /// `get_lock` with a zero timeout returns immediately: 1 got it, 0 timed out.
+    fn try_lock(c: &mut MySqlConn) -> Option<i64> {
+        c.conn
+            .query_first(format!("select get_lock('{}', 0)", ADVISORY_LOCK_NAME))
+            .unwrap()
+            .flatten()
+    }
+
+    /// While one session holds the lock, another cannot, and it becomes
+    /// available again once released.
+    fn lock_is_exclusive(conn_str: &str) {
+        let mut holder = MySqlConn::connect(conn_str).unwrap();
+        let mut other = MySqlConn::connect(conn_str).unwrap();
 
         holder.acquire_lock().unwrap();
         assert_eq!(
@@ -193,6 +201,36 @@ mod tests {
             try_lock(&mut other),
             "lock must be available once released"
         );
+        other.release_lock().unwrap();
+    }
+
+    /// The session-scoped lock survives a failed statement inside an explicit
+    /// transaction followed by the in-place rollback recovery `with_conn`
+    /// performs on server errors.
+    fn lock_survives_in_transaction_error(conn_str: &str) {
+        let mut holder = MySqlConn::connect(conn_str).unwrap();
+        let mut other = MySqlConn::connect(conn_str).unwrap();
+
+        holder.acquire_lock().unwrap();
+        // Provoke an error inside an explicit transaction.
+        holder.begin().unwrap();
+        assert!(holder
+            .execute_batch("select * from does_not_exist")
+            .is_err());
+        // Recover in place, exactly as `with_conn` does on a server error.
+        holder.rollback().unwrap();
+
+        // The session survived, so it still holds the lock.
+        assert_eq!(
+            Some(0),
+            try_lock(&mut other),
+            "advisory lock must survive an in-transaction error"
+        );
+        // The recovered connection is usable again.
+        let one: Option<i64> = holder.conn.query_first("select 1").unwrap();
+        assert_eq!(Some(1), one);
+
+        holder.release_lock().unwrap();
         other.release_lock().unwrap();
     }
 }

--- a/migrant_lib/src/lib.rs
+++ b/migrant_lib/src/lib.rs
@@ -147,7 +147,7 @@ pub use crate::connection::ConnConfig;
 pub use crate::errors::{Error, Result};
 pub use crate::migratable::Migratable;
 pub use crate::migration::{EmbeddedMigration, FileMigration, FnMigration};
-pub use crate::migrator::{Direction, Migrator};
+pub use crate::migrator::{Direction, ForceMode, Migrator};
 pub use crate::ops::{
     edit, list, migration_statuses, new, search_for_settings_file, shell, MigrationStatus,
 };

--- a/migrant_lib/src/migrator.rs
+++ b/migrant_lib/src/migrator.rs
@@ -1,6 +1,7 @@
 /*!
 Migration application
 */
+use std::collections::HashSet;
 use std::fmt;
 
 use crate::config::Config;
@@ -31,12 +32,52 @@ impl fmt::Display for Direction {
     }
 }
 
+/// How a run handles a migration that fails to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ForceMode {
+    /// A failed migration aborts the run with an error (default).
+    #[default]
+    Off,
+    /// Continue past a failed migration and record it as applied anyway.
+    /// The failed migration will *not* be retried on the next run.
+    AcceptFailures,
+    /// Continue past a failed migration without recording it. The migration
+    /// is skipped for the remainder of this run and retried on the next run.
+    SkipFailures,
+}
+
+impl fmt::Display for ForceMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ForceMode::Off => write!(f, "off"),
+            ForceMode::AcceptFailures => write!(f, "accept-failures"),
+            ForceMode::SkipFailures => write!(f, "skip-failures"),
+        }
+    }
+}
+
+impl std::str::FromStr for ForceMode {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(match s {
+            "off" => ForceMode::Off,
+            "accept-failures" => ForceMode::AcceptFailures,
+            "skip-failures" => ForceMode::SkipFailures,
+            _ => bail!(
+                Migration,
+                "Invalid force mode: `{}`. Expected one of: off, accept-failures, skip-failures",
+                s
+            ),
+        })
+    }
+}
+
 /// Migration applicator
 #[derive(Debug, Clone)]
 pub struct Migrator {
     config: Config,
     direction: Direction,
-    force: bool,
+    force: ForceMode,
     fake: bool,
     all: bool,
     show_output: bool,
@@ -50,7 +91,7 @@ impl Migrator {
         Self {
             config: config.clone(),
             direction: Direction::Up,
-            force: false,
+            force: ForceMode::Off,
             fake: false,
             all: false,
             show_output: true,
@@ -67,8 +108,15 @@ impl Migrator {
         self
     }
 
-    /// Set `force` to forcefully apply migrations regardless of errors
-    pub fn force(&mut self, force: bool) -> &mut Self {
+    /// Set how the run handles a migration that fails to apply.
+    /// Default is `ForceMode::Off`: a failed migration aborts the run.
+    ///
+    /// `ForceMode::AcceptFailures` continues past a failed migration and
+    /// records it as applied anyway, so it will *not* be retried on the next
+    /// run. `ForceMode::SkipFailures` continues without recording it: the
+    /// migration is skipped for the remainder of this run and retried on the
+    /// next run, so it must be safe to re-attempt after a partial application.
+    pub fn force(&mut self, force: ForceMode) -> &mut Self {
         self.force = force;
         self
     }
@@ -139,24 +187,37 @@ impl Migrator {
 
         // For server databases, take the migration advisory lock so concurrent
         // migrators (e.g. several app instances booting at once) serialize
-        // instead of racing. Acquire it *before* re-reading applied state, then
-        // reload under the lock so we observe any migrations a peer committed
-        // while we were waiting and don't re-run them. Sqlite has no such lock
-        // (and no cross-process concurrency), so its path is unchanged.
-        let _lock = if self.synchronized && config.database_type() != DbKind::Sqlite {
+        // instead of racing. Acquire it *before* re-reading applied state so we
+        // observe any migrations a peer committed while we were waiting and
+        // don't re-run them. Sqlite has no such lock (and no cross-process
+        // concurrency), so it skips the lock.
+        let lock = if self.synchronized && config.database_type() != DbKind::Sqlite {
             config.acquire_migration_lock()?;
-            // Guard is created before `reload` so the lock is released even if
-            // the reload fails; the reloaded config shares this connection.
-            let guard = MigrationLock::new(&config);
-            config = config.reload()?;
-            Some(guard)
+            Some(MigrationLock::new(&config))
         } else {
             None
         };
+        // Generation of the connection the lock was taken on. If that
+        // connection is ever dropped and re-established mid-run, the session
+        // -- and the advisory lock with it -- is gone, so a synchronized run
+        // must abort rather than continue unserialized.
+        let lock_generation = lock.as_ref().map(|_| config.connection_generation());
 
+        // Re-read applied state from the database on the (locked) connection.
+        // This intentionally does not use `Config::reload`, which re-reads the
+        // settings file and can swap in a *new* connection if the settings
+        // changed -- the whole run must stay on the connection the lock was
+        // acquired on. It also means consumers don't need to remember to call
+        // `Config::reload` themselves before applying.
+        config.refresh_applied()?;
+
+        // Tags that failed under `ForceMode::SkipFailures`, excluded from
+        // migration selection for the remainder of this run.
+        let mut skipped = HashSet::new();
         let mut applied_any = false;
         loop {
-            match self.apply_next(&config) {
+            self.check_lock_still_held(&config, lock_generation)?;
+            match self.apply_next(&config, &mut skipped, lock_generation) {
                 Ok(()) => {}
                 Err(e) if e.is_migration_complete() && self.all && applied_any => return Ok(()),
                 Err(e) => return Err(e),
@@ -165,8 +226,25 @@ impl Migrator {
             if !self.all {
                 return Ok(());
             }
-            config = config.reload()?;
+            config.refresh_applied()?;
         }
+    }
+
+    /// Bail out of a synchronized run if the connection the advisory lock was
+    /// acquired on has been dropped and re-established: the lock died with the
+    /// original session, so continuing would run unserialized.
+    fn check_lock_still_held(&self, config: &Config, lock_generation: Option<u64>) -> Result<()> {
+        if let Some(generation) = lock_generation {
+            if config.connection_generation() != generation {
+                bail!(
+                    Migration,
+                    "The database connection was lost mid-run and re-established; \
+                     the migration advisory lock was released with the original \
+                     session. Aborting this run -- re-run migrations."
+                )
+            }
+        }
+        Ok(())
     }
 
     /// The set of migrations being managed: either those explicitly defined
@@ -184,16 +262,18 @@ impl Migrator {
         })
     }
 
-    /// Return the next available up or down migration
+    /// Return the next available up or down migration, excluding any tags
+    /// skipped earlier in this run (`ForceMode::SkipFailures`)
     fn next_available<'a>(
         direction: Direction,
         available: &'a [Box<dyn Migratable>],
         applied: &[String],
+        skipped: &HashSet<String>,
     ) -> Result<Option<&'a dyn Migratable>> {
         Ok(match direction {
             Direction::Up => available
                 .iter()
-                .find(|m| !applied.contains(&m.tag()))
+                .find(|m| !applied.contains(&m.tag()) && !skipped.contains(&m.tag()))
                 .map(AsRef::as_ref),
             Direction::Down => {
                 if applied.is_empty() {
@@ -205,31 +285,39 @@ impl Migrator {
                     // unordered `select tag from __migrant_migrations` unless
                     // running in cli-compatible mode), so we must not rely on
                     // `applied.last()`.
-                    match available.iter().rev().find(|m| applied.contains(&m.tag())) {
-                        Some(mig) => Some(mig.as_ref()),
-                        None => bail!(
+                    if !available.iter().any(|m| applied.contains(&m.tag())) {
+                        bail!(
                             MigrationNotFound,
                             "Applied migration not found in available migrations: {}",
                             applied[0]
-                        ),
+                        )
                     }
+                    available
+                        .iter()
+                        .rev()
+                        .find(|m| applied.contains(&m.tag()) && !skipped.contains(&m.tag()))
+                        .map(AsRef::as_ref)
                 }
             }
         })
     }
 
     /// Try applying the next available migration in the specified `Direction`
-    fn apply_next(&self, config: &Config) -> Result<()> {
+    fn apply_next(
+        &self,
+        config: &Config,
+        skipped: &mut HashSet<String>,
+        lock_generation: Option<u64>,
+    ) -> Result<()> {
         let migrations = Self::available_migrations(config)?;
-        let next = Self::next_available(self.direction, &migrations, &config.applied)?.ok_or_else(
-            || {
+        let next = Self::next_available(self.direction, &migrations, &config.applied, skipped)?
+            .ok_or_else(|| {
                 err!(
                     MigrationComplete,
                     "No un-applied `{}` migrations found",
                     self.direction
                 )
-            },
-        )?;
+            })?;
 
         self.print(&format!(
             "Applying[{}]: {}",
@@ -268,16 +356,32 @@ impl Migrator {
                     config.rollback_transaction();
                 }
                 self.println("");
-                if self.force {
-                    self.println(&format!(
-                        " ** Error ** (Continuing because `--force` flag was specified)\n ** {}",
-                        msg
-                    ));
-                    // Legacy `force` behavior: record the tag anyway. The
-                    // transaction (if any) was rolled back, so this stands alone.
-                    self.record_tag(config, &tag)
-                } else {
-                    bail!(Migration, "Migration was unsucessful...\n{}", msg)
+                match self.force {
+                    ForceMode::Off => bail!(Migration, "Migration was unsuccessful...\n{}", msg),
+                    ForceMode::AcceptFailures => {
+                        self.println(&format!(
+                            " ** Error ** (Continuing and recording the migration \
+                             as applied because force is `accept-failures`)\n ** {}",
+                            msg
+                        ));
+                        // The failure may have killed the connection; recording
+                        // the tag would silently reconnect without the advisory
+                        // lock, so verify the locked session is still alive first.
+                        self.check_lock_still_held(config, lock_generation)?;
+                        // The transaction (if any) was rolled back, so this
+                        // bookkeeping row stands alone.
+                        self.record_tag(config, &tag)
+                    }
+                    ForceMode::SkipFailures => {
+                        self.println(&format!(
+                            " ** Error ** (Continuing without recording because force \
+                             is `skip-failures`; the migration will be retried on the \
+                             next run)\n ** {}",
+                            msg
+                        ));
+                        skipped.insert(tag);
+                        Ok(())
+                    }
                 }
             }
         }
@@ -359,11 +463,19 @@ mod tests {
         strs.iter().map(|s| (*s).to_owned()).collect()
     }
 
+    fn no_skips() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    fn skips(strs: &[&str]) -> HashSet<String> {
+        strs.iter().map(|s| (*s).to_owned()).collect()
+    }
+
     #[test]
     fn up_picks_first_unapplied_in_definition_order() {
         let avail = available(&["a", "b", "c"]);
         let applied = tags(&["a"]);
-        let next = Migrator::next_available(Direction::Up, &avail, &applied)
+        let next = Migrator::next_available(Direction::Up, &avail, &applied, &no_skips())
             .unwrap()
             .expect("expected an un-applied migration");
         assert_eq!(next.tag(), "b");
@@ -373,7 +485,27 @@ mod tests {
     fn up_returns_none_when_all_applied() {
         let avail = available(&["a", "b"]);
         let applied = tags(&["a", "b"]);
-        let next = Migrator::next_available(Direction::Up, &avail, &applied).unwrap();
+        let next = Migrator::next_available(Direction::Up, &avail, &applied, &no_skips()).unwrap();
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn up_skips_run_skipped_tags() {
+        let avail = available(&["a", "b", "c"]);
+        let applied = tags(&["a"]);
+        // `b` failed under skip-failures earlier in the run: `c` is next.
+        let next = Migrator::next_available(Direction::Up, &avail, &applied, &skips(&["b"]))
+            .unwrap()
+            .expect("expected an un-applied migration");
+        assert_eq!(next.tag(), "c");
+    }
+
+    #[test]
+    fn up_with_all_remaining_skipped_returns_none() {
+        let avail = available(&["a", "b"]);
+        let applied = tags(&["a"]);
+        let next =
+            Migrator::next_available(Direction::Up, &avail, &applied, &skips(&["b"])).unwrap();
         assert!(next.is_none());
     }
 
@@ -384,17 +516,38 @@ mod tests {
         // migration `d`. The Down target must be `c` (the last applied tag in
         // definition order), not `applied.last()` which would be `a`.
         let applied = tags(&["b", "c", "a"]);
-        let next = Migrator::next_available(Direction::Down, &avail, &applied)
+        let next = Migrator::next_available(Direction::Down, &avail, &applied, &no_skips())
             .unwrap()
             .expect("expected a down migration");
         assert_eq!(next.tag(), "c");
     }
 
     #[test]
+    fn down_skips_run_skipped_tags() {
+        let avail = available(&["a", "b", "c"]);
+        let applied = tags(&["a", "b", "c"]);
+        // `c`'s down failed under skip-failures: `b` is next.
+        let next = Migrator::next_available(Direction::Down, &avail, &applied, &skips(&["c"]))
+            .unwrap()
+            .expect("expected a down migration");
+        assert_eq!(next.tag(), "b");
+    }
+
+    #[test]
+    fn down_with_all_applied_skipped_returns_none() {
+        let avail = available(&["a", "b"]);
+        let applied = tags(&["a", "b"]);
+        let next = Migrator::next_available(Direction::Down, &avail, &applied, &skips(&["a", "b"]))
+            .unwrap();
+        assert!(next.is_none());
+    }
+
+    #[test]
     fn down_with_empty_applied_returns_none() {
         let avail = available(&["a", "b"]);
         let applied: Vec<String> = Vec::new();
-        let next = Migrator::next_available(Direction::Down, &avail, &applied).unwrap();
+        let next =
+            Migrator::next_available(Direction::Down, &avail, &applied, &no_skips()).unwrap();
         assert!(next.is_none());
     }
 
@@ -402,7 +555,7 @@ mod tests {
     fn down_with_applied_tags_absent_from_available_errors() {
         let avail = available(&["a", "b"]);
         let applied = tags(&["x", "y"]);
-        match Migrator::next_available(Direction::Down, &avail, &applied) {
+        match Migrator::next_available(Direction::Down, &avail, &applied, &no_skips()) {
             Err(Error::MigrationNotFound(_)) => {}
             Err(other) => panic!("expected MigrationNotFound, got: {:?}", other),
             Ok(_) => panic!("expected MigrationNotFound error, got Ok"),

--- a/migrant_lib/src/ops.rs
+++ b/migrant_lib/src/ops.rs
@@ -209,14 +209,14 @@ pub fn new(config: &Config, tag: &str) -> Result<()> {
 ///
 /// Note, the respective database shell utility is expected to be available in `$PATH`.
 ///
-/// | Database    |    Utility                  |
-/// |-------------|-----------------------------|
-/// | `postgres`  | `psql`                      |
-/// | `sqlite`    | `sqlite3`                   |
-/// | `mysql`     | `mysqlsh` (`mysql-shell`)   |
+/// | Database    |    Utility                                                 |
+/// |-------------|------------------------------------------------------------|
+/// | `postgres`  | `psql`                                                     |
+/// | `sqlite`    | `sqlite3`                                                  |
+/// | `mysql`     | `mysqlsh` (`mysql-shell`) if installed, otherwise `mysql`  |
 ///
 pub fn shell(config: &Config) -> Result<()> {
-    let spec = build_shell_command(config)?;
+    let spec = build_shell_command(config, program_on_path("mysqlsh"))?;
     let mut command = Command::new(&spec.program);
     command.args(&spec.args);
     for (key, value) in &spec.envs {
@@ -249,12 +249,23 @@ struct ShellCommandSpec {
     envs: Vec<(String, String)>,
 }
 
+/// Check whether an executable with the given name exists on `$PATH`.
+fn program_on_path(name: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(name).is_file())
+}
+
 /// Build the shell invocation for the given `Config` without spawning anything.
+///
+/// `mysqlsh_available` selects the mysql client: MySQL Shell (`mysqlsh`) when
+/// it is installed, otherwise the classic `mysql` client.
 ///
 /// This is factored out of `shell()` so the command construction (in
 /// particular, that the password is kept out of `argv`) is unit-testable
 /// without a live database or an installed shell utility.
-fn build_shell_command(config: &Config) -> Result<ShellCommandSpec> {
+fn build_shell_command(config: &Config, mysqlsh_available: bool) -> Result<ShellCommandSpec> {
     match config.database_type() {
         DbKind::Sqlite => {
             if config.settings.inner.is_memory_sqlite() {
@@ -281,12 +292,35 @@ fn build_shell_command(config: &Config) -> Result<ShellCommandSpec> {
         }
         DbKind::MySql => {
             let (uri, password) = connect_uri_without_password(config)?;
-            // MySQL Shell honors `MYSQL_PWD` for classic-protocol password auth.
-            Ok(ShellCommandSpec {
-                program: "mysqlsh".to_string(),
-                args: vec!["--sql".to_string(), "--uri".to_string(), uri],
-                envs: vec![("MYSQL_PWD".to_string(), password)],
-            })
+            // Both clients honor `MYSQL_PWD` for classic-protocol password auth.
+            if mysqlsh_available {
+                Ok(ShellCommandSpec {
+                    program: "mysqlsh".to_string(),
+                    args: vec!["--sql".to_string(), "--uri".to_string(), uri],
+                    envs: vec![("MYSQL_PWD".to_string(), password)],
+                })
+            } else {
+                // The classic `mysql` client does not accept a URI; build its
+                // flags from the settings directly.
+                let server = match &config.settings.inner {
+                    DbSettings::MySql(s) => s,
+                    _ => unreachable!("database_type checked above"),
+                };
+                Ok(ShellCommandSpec {
+                    program: "mysql".to_string(),
+                    args: vec![
+                        "-h".to_string(),
+                        server.host_or_default(),
+                        "-P".to_string(),
+                        server.port_or_default("3306"),
+                        "-u".to_string(),
+                        server.database_user.clone(),
+                        "-D".to_string(),
+                        server.database_name.clone(),
+                    ],
+                    envs: vec![("MYSQL_PWD".to_string(), password)],
+                })
+            }
         }
     }
 }
@@ -480,7 +514,7 @@ mod tests {
 
     #[test]
     fn postgres_shell_keeps_password_out_of_argv() {
-        let spec = build_shell_command(&postgres_config()).unwrap();
+        let spec = build_shell_command(&postgres_config(), true).unwrap();
         assert_eq!(spec.program, "psql");
         assert_no_password_in_args(&spec.args);
         // The connect uri is still present as an argument (sans password).
@@ -496,8 +530,8 @@ mod tests {
     }
 
     #[test]
-    fn mysql_shell_keeps_password_out_of_argv() {
-        let spec = build_shell_command(&mysql_config()).unwrap();
+    fn mysqlsh_shell_keeps_password_out_of_argv() {
+        let spec = build_shell_command(&mysql_config(), true).unwrap();
         assert_eq!(spec.program, "mysqlsh");
         assert_no_password_in_args(&spec.args);
         assert!(spec.args.iter().any(|a| a.starts_with("mysql://")));
@@ -512,13 +546,56 @@ mod tests {
     }
 
     #[test]
+    fn mysql_classic_shell_fallback_keeps_password_out_of_argv() {
+        // Without mysqlsh installed, the classic `mysql` client is used with
+        // explicit host/port/user/db flags; the password stays in MYSQL_PWD.
+        let spec = build_shell_command(&mysql_config(), false).unwrap();
+        assert_eq!(spec.program, "mysql");
+        assert_no_password_in_args(&spec.args);
+        assert_eq!(
+            spec.args,
+            vec![
+                "-h",
+                "localhost",
+                "-P",
+                "3306",
+                "-u",
+                "myuser",
+                "-D",
+                "mydb"
+            ]
+        );
+        assert!(
+            spec.envs
+                .iter()
+                .any(|(k, v)| k == "MYSQL_PWD" && v == RAW_PASSWORD),
+            "MYSQL_PWD with raw password not found in {:?}",
+            spec.envs
+        );
+    }
+
+    #[test]
+    fn sqlite_shell_opens_database_path() {
+        let settings = crate::config::Settings::configure_sqlite()
+            .database_path("/tmp/some.db")
+            .unwrap()
+            .build()
+            .unwrap();
+        let config = Config::with_settings(&settings);
+        let spec = build_shell_command(&config, false).unwrap();
+        assert_eq!(spec.program, "sqlite3");
+        assert_eq!(spec.args, vec!["/tmp/some.db"]);
+        assert!(spec.envs.is_empty());
+    }
+
+    #[test]
     fn in_memory_sqlite_shell_errors() {
         let settings = crate::config::Settings::configure_sqlite()
             .memory()
             .build()
             .unwrap();
         let config = Config::with_settings(&settings);
-        let res = build_shell_command(&config);
+        let res = build_shell_command(&config, true);
         assert!(
             res.is_err(),
             "expected an error for in-memory sqlite, got {:?}",

--- a/migrant_lib/tests/server_dbs.rs
+++ b/migrant_lib/tests/server_dbs.rs
@@ -5,7 +5,7 @@
 //! and `MYSQL_TEST_CONN_STR` (e.g. `mysql://user:pass@localhost:3306/db`).
 #![cfg(any(feature = "d-postgres", feature = "d-mysql"))]
 
-use migrant_lib::{Config, Direction, EmbeddedMigration, Migrator, Settings};
+use migrant_lib::{Config, Direction, EmbeddedMigration, ForceMode, Migrator, Settings};
 
 struct ConnParts {
     name: String,
@@ -125,6 +125,54 @@ fn postgres_end_to_end() {
     // force-past-failure phase, also against the same database
     assert_force_continues_holding_lock(&conn_str, &settings);
     drop_pg_migration_table(&conn_str);
+    // synchronized(false) phase, also against the same database
+    assert_unsynchronized_run_skips_lock(&conn_str, &settings);
+    drop_pg_migration_table(&conn_str);
+}
+
+/// With `synchronized(false)` a run must not take the migration advisory lock:
+/// it completes even while another session holds that lock. Shares the
+/// postgres database with `postgres_end_to_end`, so it runs as one of its
+/// phases.
+#[cfg(feature = "d-postgres")]
+fn assert_unsynchronized_run_skips_lock(conn_str: &str, settings: &Settings) {
+    // Must match `ADVISORY_LOCK_KEY` in `src/drivers/pg.rs`.
+    const ADVISORY_LOCK_KEY: i64 = 30_796_665_483_397_364;
+
+    let mut client = postgres::Client::connect(conn_str, postgres::NoTls).unwrap();
+    let got: bool = client
+        .query_one("select pg_try_advisory_lock($1)", &[&ADVISORY_LOCK_KEY])
+        .unwrap()
+        .get(0);
+    assert!(got, "test precondition: advisory lock must be acquirable");
+
+    // Run the migrator on another thread so a regression (taking the lock and
+    // blocking on it forever) fails the test instead of hanging it.
+    let (tx, rx) = std::sync::mpsc::channel();
+    let settings = settings.clone();
+    std::thread::spawn(move || {
+        let run = || -> Result<(), migrant_lib::Error> {
+            let mut config = Config::with_settings(&settings);
+            config.use_migrations(&[EmbeddedMigration::with_tag("unsync")
+                .up("select 1;")
+                .down("select 1;")
+                .boxed()])?;
+            config.setup()?;
+            Migrator::with_config(&config)
+                .synchronized(false)
+                .show_output(false)
+                .apply()
+        };
+        tx.send(run()).expect("send unsynchronized run result");
+    });
+    let res = rx
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .expect("unsynchronized run must not block on the held advisory lock");
+    res.expect("unsynchronized run must apply cleanly");
+
+    client
+        .execute("select pg_advisory_unlock_all()", &[])
+        .unwrap();
 }
 
 /// A migration whose SQL fails partway is rolled back atomically on postgres:
@@ -199,7 +247,7 @@ fn assert_force_continues_holding_lock(conn_str: &str, settings: &Settings) {
     // the second on the same session that still holds the advisory lock.
     Migrator::with_config(&config)
         .all(true)
-        .force(true)
+        .force(ForceMode::AcceptFailures)
         .show_output(false)
         .swallow_completion(true)
         .apply()

--- a/migrant_lib/tests/sqlite.rs
+++ b/migrant_lib/tests/sqlite.rs
@@ -3,8 +3,8 @@
 #![cfg(feature = "d-sqlite")]
 
 use migrant_lib::{
-    Config, ConnConfig, Direction, EmbeddedMigration, FileMigration, FnMigration, Migrator,
-    Settings,
+    Config, ConnConfig, Direction, EmbeddedMigration, FileMigration, FnMigration, ForceMode,
+    Migrator, Settings,
 };
 
 fn seed_users(conn: ConnConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -79,6 +79,114 @@ fn failing_migration_config(no_transaction: bool) -> Config {
     let mut config = Config::with_settings(&settings);
     config.use_migrations(&[migration.boxed()]).unwrap();
     config
+}
+
+/// Build an in-memory config where the first migration fails and a second,
+/// valid migration follows it -- the shape `force` runs care about.
+fn failing_then_good_config() -> Config {
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let mut config = Config::with_settings(&settings);
+    config
+        .use_migrations(&[
+            EmbeddedMigration::with_tag("bad")
+                .up("insert into does_not_exist values (1);")
+                .down("select 1;")
+                .boxed(),
+            EmbeddedMigration::with_tag("later")
+                .up("create table later (x integer);")
+                .down("drop table later;")
+                .boxed(),
+        ])
+        .unwrap();
+    config
+}
+
+#[test]
+fn force_accept_failures_records_failed_migration() {
+    let config = failing_then_good_config();
+    config.setup().unwrap();
+
+    Migrator::with_config(&config)
+        .all(true)
+        .force(ForceMode::AcceptFailures)
+        .show_output(false)
+        .swallow_completion(true)
+        .apply()
+        .unwrap();
+
+    let config = config.reload().unwrap();
+    assert!(
+        table_exists(&config, "later"),
+        "the run must continue past the failure and apply later migrations"
+    );
+    assert_eq!(
+        vec!["bad".to_string(), "later".to_string()],
+        applied_tags(&config),
+        "accept-failures records the failed migration as applied"
+    );
+}
+
+#[test]
+fn force_skip_failures_leaves_failed_migration_unrecorded() {
+    let config = failing_then_good_config();
+    config.setup().unwrap();
+
+    Migrator::with_config(&config)
+        .all(true)
+        .force(ForceMode::SkipFailures)
+        .show_output(false)
+        .swallow_completion(true)
+        .apply()
+        .unwrap();
+
+    let config = config.reload().unwrap();
+    assert!(
+        table_exists(&config, "later"),
+        "the run must continue past the failure and apply later migrations"
+    );
+    assert_eq!(
+        vec!["later".to_string()],
+        applied_tags(&config),
+        "skip-failures must not record the failed migration"
+    );
+
+    // The skipped migration is retried on the next run (and fails again
+    // without force).
+    let res = Migrator::with_config(&config).show_output(false).apply();
+    assert!(
+        res.is_err(),
+        "the skipped migration must be selected and fail on the next run"
+    );
+}
+
+#[test]
+fn apply_refreshes_applied_state_without_manual_reload() {
+    // Consumers are not required to call `Config::reload` before applying:
+    // the migrator re-reads applied state itself, so back-to-back runs on the
+    // same un-reloaded config must not re-apply migration 1.
+    let settings = Settings::configure_sqlite().memory().build().unwrap();
+    let config = migrations_config(&settings);
+    config.setup().unwrap();
+
+    // First single apply: create-users.
+    Migrator::with_config(&config)
+        .show_output(false)
+        .apply()
+        .unwrap();
+
+    // Second single apply on the same, never-reloaded config: must pick
+    // seed-users, not fail re-running create-users.
+    Migrator::with_config(&config)
+        .show_output(false)
+        .apply()
+        .unwrap();
+
+    let config = config.reload().unwrap();
+    assert_eq!(
+        vec!["create-users".to_string(), "seed-users".to_string()],
+        applied_tags(&config)
+    );
+    assert_eq!(1, user_count(&config));
 }
 
 #[test]

--- a/spec/advisory-locking.md
+++ b/spec/advisory-locking.md
@@ -36,8 +36,17 @@ mid-run. A `force`d run therefore keeps holding the lock as it continues past a
 failed migration, with no window for another migrator to interleave. Only a
 genuinely dead connection (its rollback also fails) is dropped.
 
-Coverage: `migrant_lib/src/drivers/pg.rs`, `mysql.rs` (`advisory_lock`,
-`advisory_lock_is_exclusive`, gated on the test connection strings and run via
-`test.sh`); the `advisory_lock` test also covers lock survival across an
-in-transaction error; end-to-end apply/unapply and the `force`-past-failure
-phase through the synchronized path in `migrant_lib/tests/server_dbs.rs`.
+## LOCK-6
+
+A synchronized run never continues after its locked session is gone. If the
+connection had to be dropped and re-established mid-run (LOCK-5's dead-connection
+case), the run aborts with an error before applying or recording anything on the
+new, unlocked session. The applied-state re-read at the start of a run does not
+re-read the settings file or swap the connection (see MIGRATOR-1), so the run
+cannot silently migrate over a different connection than the one it locked.
+
+Coverage: `migrant_lib/src/drivers/pg.rs`, `mysql.rs` (`advisory_lock`, gated on
+the test connection strings and run via `test.sh`); both drivers' `advisory_lock`
+tests cover exclusivity and lock survival across an in-transaction error;
+end-to-end apply/unapply, the `force`-past-failure phase, and the
+`synchronized(false)` skip phase in `migrant_lib/tests/server_dbs.rs`.

--- a/spec/cli-migration-management.md
+++ b/spec/cli-migration-management.md
@@ -19,13 +19,17 @@ file instead.
 ## CLIMIG-4
 
 `migrant apply` applies the next unapplied migration. Flags: `--all` applies all remaining,
-`--down` reverses direction (unapplies), `--force` continues past SQL errors, `--fake` marks
-migrations applied/unapplied without executing their SQL.
+`--down` reverses direction (unapplies), `--fake` marks migrations applied/unapplied without
+executing their SQL. `--force[=<mode>]` continues past failed migrations: bare `--force` (or
+`--force=accept-failures`) records a failed migration as applied so it is not retried;
+`--force=skip-failures` leaves it unrecorded, skips it for the rest of the run, and retries
+it on the next run.
 
 ## CLIMIG-5
 
 `migrant redo` unapplies then reapplies the latest migration (`--down` then up); `--all`
 redoes all applied migrations. Down-migrations run in reverse application order.
 
-Coverage: `tests/migrant.rs` (kitchen_sink), backend integration tests, unit tests in
-`migrant_lib/src/ops.rs`.
+Coverage: `tests/migrant.rs` (kitchen_sink, new_rejects_invalid_tag,
+apply_fake_records_without_running, force_modes_through_the_cli), backend integration tests,
+unit tests in `migrant_lib/src/ops.rs`.

--- a/spec/cli-project-setup.md
+++ b/spec/cli-project-setup.md
@@ -17,11 +17,15 @@ tracking table if it does not exist.
 ## CLIPRO-3
 
 `migrant which-config` prints the path of the active `Migrant.toml`. The active config is
-found by searching upward from the current directory.
+found by searching upward from the current directory. When no config is found, every
+subcommand except `init` (and `self`) errors with a pointer to `migrant init` rather than
+starting the interactive config-creation flow.
 
 ## CLIPRO-4
 
-`migrant connect-string` prints the database connection string, or the database file path
-for SQLite.
+`migrant connect-string` prints the database connection string (postgres/mysql), or the
+database file path for SQLite.
 
-Coverage: `tests/migrant.rs` (kitchen_sink) and backend integration tests.
+Coverage: `tests/migrant.rs` (kitchen_sink, no_config_errors_and_points_at_init,
+init_non_interactive_creates_config, init_rejects_invalid_database_type) and backend
+integration tests.

--- a/spec/config-file-and-env-resolution.md
+++ b/spec/config-file-and-env-resolution.md
@@ -7,16 +7,22 @@ Migrant.toml format, env:VAR value resolution, and automatic .env loading.
 `Migrant.toml` keys: `database_type` (sqlite|postgres|mysql), `migration_location`,
 `database_path` (SQLite), `database_name`/`database_user`/`database_password`/
 `database_host`/`database_port` (server databases), `ssl_cert_file` (postgres), and
-`database_params` (key-value connection parameters).
+`database_params` (key-value connection parameters). `database_port` accepts a TOML
+integer or a string.
 
 ## CONFIG-2
 
-Any config value written as `env:VAR_NAME` resolves from the environment when the config
-is loaded.
+Any config value written as `env:VAR_NAME` resolves from the process environment when
+the config is loaded. This covers every settings value, including `ssl_cert_file` and
+both keys and values of `database_params`. A referenced variable that is not set is a
+hard error naming the variable.
 
 ## CONFIG-3
 
-A `.env` file is loaded automatically (via dotenvy) before config values are resolved.
+The `migrant` CLI loads a `.env` file automatically (via dotenvy) before config values
+are resolved. The library does not: `Config::from_settings_file` resolves `env:` values
+from the process environment as-is, and loading a `.env` file is the consumer's
+responsibility.
 
 ## CONFIG-4
 

--- a/spec/database-shell.md
+++ b/spec/database-shell.md
@@ -4,7 +4,10 @@ shell subcommand opening an interactive REPL to the configured database.
 
 ## SHELL-1
 
-`migrant shell` opens the backend's interactive client (`sqlite3`, `psql`, or `mysql`)
-connected to the configured database.
+`migrant shell` opens the backend's interactive client connected to the configured
+database: `sqlite3`, `psql`, or for mysql the MySQL Shell (`mysqlsh`) when it is on
+`$PATH` and the classic `mysql` client otherwise. Server-database passwords are passed
+via environment (`PGPASSWORD`/`MYSQL_PWD`), never in argv.
 
-Coverage: unit tests in `migrant_lib/src/ops.rs`.
+Coverage: unit tests in `migrant_lib/src/ops.rs` (all backends, both mysql clients,
+in-memory sqlite error).

--- a/spec/migrator-api.md
+++ b/spec/migrator-api.md
@@ -5,7 +5,11 @@ Migrator builder: direction, all, force, fake, show_output, swallow_completion, 
 ## MIGRATOR-1
 
 `Migrator::with_config(&config)` creates a migrator; `apply()` executes pending
-migrations against the live connection.
+migrations against the live connection. A run re-reads applied state from the
+database itself (for every backend), so consumers do not need to call
+`Config::reload` before applying. The re-read never re-reads the settings file
+or swaps the live connection: the whole run stays on the connection it started
+(and, when synchronized, took the advisory lock) on.
 
 ## MIGRATOR-2
 
@@ -14,8 +18,19 @@ remaining migration in that direction instead of just the next one.
 
 ## MIGRATOR-3
 
-`force(bool)` continues applying past SQL errors; `fake(bool)` updates the tracking table
-without executing migration SQL.
+`force(ForceMode)` controls how a run handles a migration that fails to apply:
+
+- `ForceMode::Off` (default): the failure aborts the run with an error and the
+  migration is not recorded.
+- `ForceMode::AcceptFailures`: the run continues and the failed migration is
+  recorded as applied anyway, so it is not retried on later runs.
+- `ForceMode::SkipFailures`: the run continues without recording the failed
+  migration; it is skipped for the remainder of the run (so an `all` run
+  terminates) and retried on the next run.
+
+`ForceMode` parses from `off` / `accept-failures` / `skip-failures`
+(`FromStr`). `fake(bool)` updates the tracking table without executing
+migration SQL.
 
 ## MIGRATOR-4
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,24 @@
 use clap::{Arg, ArgAction, Command};
 
+/// `--force[=<mode>]`: continue past failed migrations.
+/// Bare `--force` means `accept-failures` (record the failed migration as
+/// applied); `--force=skip-failures` continues without recording so the
+/// migration is retried on the next run.
+fn force_arg() -> Arg {
+    Arg::new("force")
+        .long("force")
+        .num_args(0..=1)
+        .require_equals(true)
+        .value_parser(["accept-failures", "skip-failures"])
+        .default_missing_value("accept-failures")
+        .value_name("mode")
+        .help(
+            "Continue past failed migrations. `accept-failures` (the default) records a \
+             failed migration as applied; `skip-failures` leaves it unrecorded so it is \
+             retried on the next run",
+        )
+}
+
 pub fn build_cli() -> Command {
     Command::new("migrant")
         .version(env!("CARGO_PKG_VERSION"))
@@ -72,7 +91,7 @@ pub fn build_cli() -> Command {
         .subcommand(Command::new("setup").about("Setup migration table"))
         .subcommand(
             Command::new("connect-string")
-                .about("Print out the connection string for postgres, or file-path for sqlite"),
+                .about("Print out the connection string for server databases (postgres/mysql), or file-path for sqlite"),
         )
         .subcommand(
             Command::new("list").about("List status of applied and available migrations"),
@@ -94,12 +113,7 @@ pub fn build_cli() -> Command {
                         .action(ArgAction::SetTrue)
                         .help("Applies all remaining migrations in the chosen direction (un-applies all with --down)"),
                 )
-                .arg(
-                    Arg::new("force")
-                        .long("force")
-                        .action(ArgAction::SetTrue)
-                        .help("Applies migrations, ignoring errors"),
-                )
+                .arg(force_arg())
                 .arg(
                     Arg::new("fake")
                         .long("fake")
@@ -115,14 +129,9 @@ pub fn build_cli() -> Command {
                         .long("all")
                         .short('a')
                         .action(ArgAction::SetTrue)
-                        .help("Applies all remaining migrations in the chosen direction (un-applies all with --down)"),
+                        .help("Re-applies (down, then up) all applied migrations instead of only the latest"),
                 )
-                .arg(
-                    Arg::new("force")
-                        .long("force")
-                        .action(ArgAction::SetTrue)
-                        .help("Applies migrations, ignoring errors"),
-                ),
+                .arg(force_arg()),
         )
         .subcommand(
             Command::new("new")

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use migrant_lib::config::{MySqlSettingsBuilder, PostgresSettingsBuilder, SqliteSettingsBuilder};
-use migrant_lib::{Config, DbKind, Direction, Migrator};
+use migrant_lib::{Config, DbKind, Direction, ForceMode, Migrator};
 
 mod cli;
 mod tui;
@@ -31,43 +31,45 @@ fn run(dir: &Path, matches: &clap::ArgMatches) -> Result<()> {
         return run_self(self_matches);
     }
 
-    let config_path = migrant_lib::search_for_settings_file(dir);
-
-    if matches.subcommand_matches("init").is_some() || config_path.is_none() {
-        let initializer = match matches.subcommand_matches("init") {
-            None => Config::init_in(dir),
-            Some(init_matches) => {
-                let from_env = init_matches.get_flag("default-from-env");
-                let dir = init_matches
-                    .get_one::<String>("location")
-                    .map(PathBuf::from)
-                    .unwrap_or_else(|| dir.to_owned());
-                let mut initializer = Config::init_in(&dir);
-                initializer.interactive(!init_matches.get_flag("no-confirm"));
-                initializer.with_env_defaults(from_env);
-                if let Some(db_kind) = init_matches.get_one::<String>("type") {
-                    match db_kind.parse::<DbKind>()? {
-                        DbKind::Sqlite => {
-                            initializer.with_sqlite_options(&SqliteSettingsBuilder::empty());
-                        }
-                        DbKind::Postgres => {
-                            initializer.with_postgres_options(&PostgresSettingsBuilder::empty());
-                        }
-                        DbKind::MySql => {
-                            initializer.with_mysql_options(&MySqlSettingsBuilder::empty());
-                        }
-                    }
+    if let Some(init_matches) = matches.subcommand_matches("init") {
+        let from_env = init_matches.get_flag("default-from-env");
+        let dir = init_matches
+            .get_one::<String>("location")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| dir.to_owned());
+        let mut initializer = Config::init_in(&dir);
+        initializer.interactive(!init_matches.get_flag("no-confirm"));
+        initializer.with_env_defaults(from_env);
+        if let Some(db_kind) = init_matches.get_one::<String>("type") {
+            match db_kind.parse::<DbKind>()? {
+                DbKind::Sqlite => {
+                    initializer.with_sqlite_options(&SqliteSettingsBuilder::empty());
                 }
-                initializer
+                DbKind::Postgres => {
+                    initializer.with_postgres_options(&PostgresSettingsBuilder::empty());
+                }
+                DbKind::MySql => {
+                    initializer.with_mysql_options(&MySqlSettingsBuilder::empty());
+                }
             }
-        };
+        }
         initializer.initialize()?;
         return Ok(());
     }
 
-    // Absolute path of `Migrant.toml` file
-    // This file must exist at this point, created by the block above
-    let config_path = config_path.expect("Settings file must exist");
+    // Absolute path of the `Migrant.toml` file. Only `init` creates one;
+    // everything else requires it to already exist.
+    let config_path = match migrant_lib::search_for_settings_file(dir) {
+        Some(path) => path,
+        None => {
+            return Err(format!(
+                "No `Migrant.toml` found in `{}` or any parent directory. \
+                 Run `migrant init` to create one.",
+                dir.display()
+            )
+            .into())
+        }
+    };
     let mut config = Config::from_settings_file(&config_path)?;
     config.use_cli_compatible_tags(true);
 
@@ -105,7 +107,7 @@ fn run(dir: &Path, matches: &clap::ArgMatches) -> Result<()> {
             // load applied migrations from the database
             let config = config.reload()?;
 
-            let force = matches.get_flag("force");
+            let force = force_mode(matches)?;
             let fake = matches.get_flag("fake");
             let all = matches.get_flag("all");
             let direction = if matches.get_flag("down") {
@@ -128,7 +130,7 @@ fn run(dir: &Path, matches: &clap::ArgMatches) -> Result<()> {
             // load applied migrations from the database
             let config = config.reload()?;
 
-            let force = matches.get_flag("force");
+            let force = force_mode(matches)?;
             let all = matches.get_flag("all");
 
             Migrator::with_config(&config)
@@ -173,6 +175,15 @@ fn run(dir: &Path, matches: &clap::ArgMatches) -> Result<()> {
         }
     };
     Ok(())
+}
+
+/// Map the optional-valued `--force[=<mode>]` flag to a `ForceMode`.
+/// Bare `--force` carries the default-missing-value `accept-failures`.
+fn force_mode(matches: &clap::ArgMatches) -> Result<ForceMode> {
+    Ok(match matches.get_one::<String>("force") {
+        None => ForceMode::Off,
+        Some(mode) => mode.parse::<ForceMode>()?,
+    })
 }
 
 fn run_self(self_matches: &clap::ArgMatches) -> Result<()> {

--- a/tests/migrant.rs
+++ b/tests/migrant.rs
@@ -100,3 +100,185 @@ fn tui_requires_an_interactive_terminal() {
         .failure()
         .stderr(contains("requires an interactive terminal"));
 }
+
+/// A tempdir with a sqlite `Migrant.toml`, isolated from the repo's own
+/// config (and from the other tests, so these run in parallel safely).
+fn sqlite_project() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(
+        dir.path().join("Migrant.toml"),
+        "database_type = \"sqlite\"\n\
+         database_path = \"db.db\"\n\
+         migration_location = \"migrations\"\n",
+    )
+    .expect("write Migrant.toml");
+    dir
+}
+
+/// Create a migration via `migrant new` and overwrite its up/down files.
+fn new_migration(dir: &std::path::Path, tag: &str, up: &str, down: &str) {
+    migrant()
+        .current_dir(dir)
+        .args(["new", tag])
+        .assert()
+        .success();
+    let migrations = dir.join("migrations");
+    let mig_dir = std::fs::read_dir(&migrations)
+        .expect("read migrations dir")
+        .map(|e| e.expect("dir entry").path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(&format!("_{}", tag)))
+        })
+        .unwrap_or_else(|| panic!("migration dir for `{}` not found", tag));
+    std::fs::write(mig_dir.join("up.sql"), up).expect("write up.sql");
+    std::fs::write(mig_dir.join("down.sql"), down).expect("write down.sql");
+}
+
+// CLIPRO-3: without a config, commands error and point at `init` instead of
+// silently starting the interactive config-creation flow.
+#[test]
+fn no_config_errors_and_points_at_init() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    for cmd in ["list", "which-config", "setup", "connect-string"] {
+        migrant()
+            .current_dir(dir.path())
+            .arg(cmd)
+            .assert()
+            .failure()
+            .stderr(contains("No `Migrant.toml` found"))
+            .stderr(contains("migrant init"));
+    }
+}
+
+// CLIPRO-1: non-interactive `init` writes a config without prompting.
+#[test]
+fn init_non_interactive_creates_config() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    migrant()
+        .current_dir(dir.path())
+        .args(["init", "-t", "sqlite", "--no-confirm"])
+        .assert()
+        .success();
+    let config = std::fs::read_to_string(dir.path().join("Migrant.toml"))
+        .expect("Migrant.toml must be created");
+    assert!(config.contains("database_type = \"sqlite\""));
+}
+
+#[test]
+fn init_rejects_invalid_database_type() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    migrant()
+        .current_dir(dir.path())
+        .args(["init", "-t", "nosuchdb", "--no-confirm"])
+        .assert()
+        .failure()
+        .stderr(contains("Invalid Database Kind"));
+    assert!(
+        !dir.path().join("Migrant.toml").exists(),
+        "no config may be written on error"
+    );
+}
+
+// CLIMIG-1: `new` validates tags before creating anything.
+#[test]
+fn new_rejects_invalid_tag() {
+    let dir = sqlite_project();
+    migrant()
+        .current_dir(dir.path())
+        .arg("setup")
+        .assert()
+        .success();
+    migrant()
+        .current_dir(dir.path())
+        .args(["new", "Bad_Tag!"])
+        .assert()
+        .failure()
+        .stderr(contains("Invalid tag"));
+}
+
+// CLIMIG-4: `--fake` records the migration without running its SQL.
+#[test]
+fn apply_fake_records_without_running() {
+    let dir = sqlite_project();
+    migrant()
+        .current_dir(dir.path())
+        .arg("setup")
+        .assert()
+        .success();
+    new_migration(
+        dir.path(),
+        "first",
+        "create table fake_check (x integer);",
+        "drop table fake_check;",
+    );
+
+    migrant()
+        .current_dir(dir.path())
+        .args(["apply", "--fake"])
+        .assert()
+        .success()
+        .stdout(contains("(fake)"))
+        .stdout(contains("[✓]"));
+
+    // The migration SQL never ran: un-applying for real would fail to drop
+    // the table, so fake the down as well and just verify the status flipped.
+    migrant()
+        .current_dir(dir.path())
+        .args(["apply", "--fake", "-d"])
+        .assert()
+        .success()
+        .stdout(contains("[ ]"));
+}
+
+// CLIMIG-4: `--force=skip-failures` continues without recording the failed
+// migration; bare `--force` (accept-failures) records it.
+#[test]
+fn force_modes_through_the_cli() {
+    let dir = sqlite_project();
+    migrant()
+        .current_dir(dir.path())
+        .arg("setup")
+        .assert()
+        .success();
+    new_migration(
+        dir.path(),
+        "a-bad",
+        "insert into does_not_exist values (1);",
+        "select 1;",
+    );
+    new_migration(
+        dir.path(),
+        "b-good",
+        "create table good_things (x integer);",
+        "drop table good_things;",
+    );
+
+    migrant()
+        .current_dir(dir.path())
+        .args(["apply", "--all", "--force=skip-failures"])
+        .assert()
+        .success()
+        .stdout(contains("skip-failures"));
+    migrant()
+        .current_dir(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_match(r"\[ \] \d{14}_a-bad").expect("valid regex"))
+        .stdout(predicates::str::is_match(r"\[✓\] \d{14}_b-good").expect("valid regex"));
+
+    // Bare `--force` records the still-failing migration as applied.
+    migrant()
+        .current_dir(dir.path())
+        .args(["apply", "--all", "--force"])
+        .assert()
+        .success();
+    migrant()
+        .current_dir(dir.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_match(r"\[✓\] \d{14}_a-bad").expect("valid regex"));
+}


### PR DESCRIPTION
- Change `Migrator::force` to take a `ForceMode` (`Off`/`AcceptFailures`/`SkipFailures`) instead of a bool. `AcceptFailures` records a failed migration as applied and continues (previous force behavior); `SkipFailures` continues without recording, skips the migration for the rest of the run, and retries it on the next run. CLI: `--force[=accept-failures|skip-failures]`, bare `--force` means accept-failures. Breaking for `migrant_lib` consumers using `force(bool)`.
- Make `Migrator::apply` re-read applied state itself for every backend, so a manual `Config::reload` before applying is no longer needed. The re-read stays on the run's own connection and never re-reads the settings file, so a synchronized run cannot migrate over a different connection than the one holding the advisory lock.
- Abort a synchronized run with an error if the locked connection dies and is re-established mid-run (connection-generation counter bumped when a dead connection is dropped), instead of continuing without the lock.
- Error with a pointer to `migrant init` when any subcommand other than `init` runs without a `Migrant.toml`, instead of starting the interactive config-creation flow.
- Fall back to the classic `mysql` client for `migrant shell` when `mysqlsh` is not on `PATH`; password stays in `MYSQL_PWD`, never argv.
- Accept a TOML integer or string for `database_port`; resolve `env:` references in `ssl_cert_file` and `database_params` keys.
- Fix `connect-string` and `redo --all` help text.
- Update spec/ (MIGRATOR-1/3, LOCK-6, CLIMIG-4, CLIPRO-3/4, SHELL-1, CONFIG-1/2/3), the guide, and both changelogs.
- Add tests: force modes (sqlite + CLI), apply-without-reload, `synchronized(false)` skip phase (postgres), mysql advisory-lock survival across an in-transaction error, mysql/sqlite shell argv, non-interactive `init`, `new` tag validation, `apply --fake`, no-config error. Full `migrant_lib/test.sh` docker suite passes.