### PR TITLE
modernize docker image and publish it on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
 name: release
 
-# Library releases are tagged `lib-v<version>` and published to crates.io.
-# CLI releases are tagged `cli-v<version>`, published to crates.io, and
-# release binaries are built and attached to a GitHub release.
+# Library releases are tagged `lib-v<version>`; CLI releases are tagged
+# `cli-v<version>`. Both can be tagged and pushed together.
 #
-# Note: a `cli-v*` release requires the `migrant_lib` version it depends on
-# to already be published, so tag `lib-v*` first when both change.
+# A `lib-v*` tag publishes `migrant_lib` to crates.io.
+#
+# A `cli-v*` tag builds the release binaries first, attaches them to a GitHub
+# release, publishes the Docker image, and only then publishes `migrant` to
+# crates.io. Because `migrant` depends on `migrant_lib`, the crates.io publish
+# waits for the required `migrant_lib` version to appear on the index, so the
+# two tags can be pushed at the same time (the `lib-v*` run publishes the
+# library while the `cli-v*` run builds and releases).
+#
+# crates.io publishes come last in each run because they cannot be undone.
 on:
   push:
     tags:
@@ -19,6 +26,7 @@ permissions:
   contents: read
 
 jobs:
+  # --- library release (lib-v*) ---------------------------------------------
   publish-lib:
     if: startsWith(github.ref_name, 'lib-v')
     environment: Release
@@ -40,41 +48,15 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish migrant_lib to crates.io
-        run: cargo publish -p migrant_lib
+        run: cargo publish -p migrant_lib --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-  publish-cli:
+  # --- cli release (cli-v*) -------------------------------------------------
+  # Build all target binaries first. Nothing here is irreversible, so a build
+  # failure never leaves a partial release behind.
+  build-cli:
     if: startsWith(github.ref_name, 'cli-v')
-    environment: Release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Verify tag matches crate version
-        run: |
-          tag_version="${GITHUB_REF_NAME#cli-v}"
-          crate_version="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name == "migrant") | .version')"
-          echo "tag: $tag_version, crate: $crate_version"
-          test "$tag_version" = "$crate_version"
-      - name: Authenticate to crates.io
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-      - name: Publish migrant to crates.io
-        run: cargo publish -p migrant
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-  release-binaries:
-    needs: publish-cli
-    if: startsWith(github.ref_name, 'cli-v')
-    environment: Release
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +82,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Verify tag matches crate version
+        if: matrix.os != 'windows-latest'
+        run: |
+          tag_version="${GITHUB_REF_NAME#cli-v}"
+          crate_version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "migrant") | .version')"
+          echo "tag: $tag_version, crate: $crate_version"
+          test "$tag_version" = "$crate_version"
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -125,16 +115,40 @@ jobs:
           Copy-Item "target/${{ matrix.target }}/release/migrant.exe" $name
           Copy-Item README.md,LICENSE $name
           Compress-Archive -Path $name -DestinationPath "$name.zip"
-      - name: Upload release assets
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: |
+            migrant-*.tar.gz
+            migrant-*.zip
+          if-no-files-found: error
+
+  # Assemble the GitHub release from the pre-built artifacts. Reversible.
+  github-release:
+    if: startsWith(github.ref_name, 'cli-v')
+    needs: build-cli
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+      - name: Create release and upload binaries
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            migrant-*.tar.gz
-            migrant-*.zip
+            dist/migrant-*.tar.gz
+            dist/migrant-*.zip
 
+  # Build and push the Docker image from the released musl binary. Reversible.
   docker-publish:
-    needs: release-binaries
     if: startsWith(github.ref_name, 'cli-v')
+    needs: github-release
     environment: Release
     runs-on: ubuntu-latest
     steps:
@@ -165,3 +179,41 @@ jobs:
           build-args: |
             MIGRANT_VERSION=${{ github.ref_name }}
           tags: ${{ steps.tags.outputs.tags }}
+
+  # crates.io publish is last: it cannot be undone. Runs only after the
+  # binaries, GitHub release, and Docker image are done, and once the required
+  # `migrant_lib` version is on the crates.io index.
+  publish-cli:
+    if: startsWith(github.ref_name, 'cli-v')
+    needs: [github-release, docker-publish]
+    environment: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Wait for migrant_lib on crates.io
+        run: |
+          lib_version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "migrant_lib") | .version')"
+          echo "waiting for migrant_lib ${lib_version} on the crates.io index"
+          for i in $(seq 1 30); do
+            if curl -sf "https://index.crates.io/mi/gr/migrant_lib" \
+                 | grep -qF "\"vers\":\"${lib_version}\""; then
+              echo "migrant_lib ${lib_version} is available"
+              exit 0
+            fi
+            echo "not yet available, retrying in 10s ($i/30)"
+            sleep 10
+          done
+          echo "timed out waiting for migrant_lib ${lib_version} on crates.io"
+          exit 1
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish migrant to crates.io
+        run: cargo publish -p migrant --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,24 @@ jobs:
             | jq -r '.packages[] | select(.name == "migrant_lib") | .version')"
           echo "tag: $tag_version, crate: $crate_version"
           test "$tag_version" = "$crate_version"
+      - name: Skip if already published
+        id: check
+        run: |
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "migrant_lib") | .version')"
+          if curl -sf "https://index.crates.io/mi/gr/migrant_lib" \
+               | grep -qF "\"vers\":\"${version}\""; then
+            echo "migrant_lib ${version} is already on crates.io; skipping publish"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Authenticate to crates.io
+        if: steps.check.outputs.publish == 'true'
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish migrant_lib to crates.io
+        if: steps.check.outputs.publish == 'true'
         run: cargo publish -p migrant_lib --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
@@ -123,6 +137,7 @@ jobs:
             migrant-*.tar.gz
             migrant-*.zip
           if-no-files-found: error
+          overwrite: true
 
   # Assemble the GitHub release from the pre-built artifacts. Reversible.
   github-release:
@@ -211,10 +226,24 @@ jobs:
           done
           echo "timed out waiting for migrant_lib ${lib_version} on crates.io"
           exit 1
+      - name: Skip if already published
+        id: check
+        run: |
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "migrant") | .version')"
+          if curl -sf "https://index.crates.io/mi/gr/migrant" \
+               | grep -qF "\"vers\":\"${version}\""; then
+            echo "migrant ${version} is already on crates.io; skipping publish"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Authenticate to crates.io
+        if: steps.check.outputs.publish == 'true'
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish migrant to crates.io
+        if: steps.check.outputs.publish == 'true'
         run: cargo publish -p migrant --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   publish-lib:
     if: startsWith(github.ref_name, 'lib-v')
+    environment: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
 
   publish-cli:
     if: startsWith(github.ref_name, 'cli-v')
+    environment: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +56,7 @@ jobs:
   release-binaries:
     needs: publish-cli
     if: startsWith(github.ref_name, 'cli-v')
+    environment: Release
     permissions:
       contents: write
     strategy:
@@ -116,6 +119,7 @@ jobs:
   docker-publish:
     needs: release-binaries
     if: startsWith(github.ref_name, 'cli-v')
+    environment: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,12 +180,13 @@ jobs:
             MIGRANT_VERSION=${{ github.ref_name }}
           tags: ${{ steps.tags.outputs.tags }}
 
-  # crates.io publish is last: it cannot be undone. Runs only after the
-  # binaries, GitHub release, and Docker image are done, and once the required
-  # `migrant_lib` version is on the crates.io index.
+  # crates.io publish is last: it cannot be undone. Runs after the binaries are
+  # built and the GitHub release is created, and once the required `migrant_lib`
+  # version is on the crates.io index. It does not depend on the Docker push, so
+  # a Docker Hub failure never blocks publishing `migrant` to crates.io.
   publish-cli:
     if: startsWith(github.ref_name, 'cli-v')
-    needs: [github-release, docker-publish]
+    needs: github-release
     environment: Release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
     if: startsWith(github.ref_name, 'lib-v')
     environment: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -33,13 +36,21 @@ jobs:
             | jq -r '.packages[] | select(.name == "migrant_lib") | .version')"
           echo "tag: $tag_version, crate: $crate_version"
           test "$tag_version" = "$crate_version"
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish migrant_lib to crates.io
-        run: cargo publish -p migrant_lib --token "${{ secrets.CRATES_IO_TOKEN }}"
+        run: cargo publish -p migrant_lib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   publish-cli:
     if: startsWith(github.ref_name, 'cli-v')
     environment: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -50,8 +61,13 @@ jobs:
             | jq -r '.packages[] | select(.name == "migrant") | .version')"
           echo "tag: $tag_version, crate: $crate_version"
           test "$tag_version" = "$crate_version"
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish migrant to crates.io
-        run: cargo publish -p migrant --token "${{ secrets.CRATES_IO_TOKEN }}"
+        run: cargo publish -p migrant
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   release-binaries:
     needs: publish-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,36 @@ jobs:
           files: |
             migrant-*.tar.gz
             migrant-*.zip
+
+  docker-publish:
+    needs: release-binaries
+    if: startsWith(github.ref_name, 'cli-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute image tags
+        id: tags
+        run: |
+          version="${GITHUB_REF_NAME#cli-v}"
+          tags="jaemk/migrant:${version}"
+          # Only move `latest` for full releases, not prereleases (e.g. rc/beta,
+          # which carry a `-` in the semver).
+          case "$version" in
+            *-*) ;;
+            *) tags="${tags},jaemk/migrant:latest" ;;
+          esac
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          push: true
+          build-args: |
+            MIGRANT_VERSION=${{ github.ref_name }}
+          tags: ${{ steps.tags.outputs.tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,30 @@
-FROM ubuntu:16.04
+# Minimal image wrapping a published `migrant` CLI release binary.
+#
+# The Linux musl release build is fully static (its openssl is vendored), so it
+# runs on a bare alpine base with only CA certificates added for TLS.
+#
+# Build arg `MIGRANT_VERSION` is the full CLI release tag, e.g. `cli-v1.0.0-rc.1`.
+# The release workflow builds this automatically; to build by hand:
+#   docker build -t migrant docker \
+#     --build-arg MIGRANT_VERSION=cli-v1.0.0-rc.1
+FROM alpine:3.20
 
-RUN apt-get update && apt-get install -y curl vim postgresql
-WORKDIR /usr/bin
-RUN curl -Lo migrant_download.tar.gz https://github.com/jaemk/migrant/releases/download/v0.11.4/migrant-v0.11.4-x86_64-unknown-linux-musl.tar.gz
-RUN tar -xf migrant_download.tar.gz
-RUN rm -f migrant_download.tar.gz
+ARG MIGRANT_VERSION
+ARG TARGET=x86_64-unknown-linux-musl
 
+RUN test -n "$MIGRANT_VERSION" || (echo "MIGRANT_VERSION build arg is required" && false)
+
+RUN apk add --no-cache ca-certificates \
+    && apk add --no-cache --virtual .fetch curl \
+    && asset="migrant-${MIGRANT_VERSION}-${TARGET}" \
+    && curl -fsSL -o /tmp/migrant.tar.gz \
+        "https://github.com/jaemk/migrant/releases/download/${MIGRANT_VERSION}/${asset}.tar.gz" \
+    && tar -xzf /tmp/migrant.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/${asset}/migrant" /usr/local/bin/migrant \
+    && rm -rf /tmp/migrant.tar.gz "/tmp/${asset}" \
+    && apk del .fetch \
+    && migrant --help >/dev/null
+
+# `migrant` is on PATH, so `docker run <image> migrant <subcommand>` works; a
+# bare run prints help.
+CMD ["migrant", "--help"]


### PR DESCRIPTION
# modernize docker image and publish it on release

- Rebuild `docker/Dockerfile` on `alpine:3.20`, dropping the `ubuntu:16.04` base and the hardcoded `v0.11.4` download. It installs the static musl release binary for the `MIGRANT_VERSION` build arg, adds CA certificates, and runs `migrant --help` at build time as a smoke test.
- Add a `docker-publish` job to the release workflow: on a `cli-v*` tag, after `release-binaries` attaches the assets, build from `docker/` and push `jaemk/migrant:<version>`. `jaemk/migrant:latest` is moved only for non-prerelease versions (a `-` in the semver marks a prerelease and is skipped).

Note that the publish job needs `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets. The Dockerfile downloads the release asset, so it only builds against a tag whose `release-binaries` run has already published the musl tarball. Local dry-run with `docker build --check` passes; a full build requires a published `cli-v*` release.
