### PR TITLE
remove deprecated `d-*` feature aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   `Migrator`, `#[non_exhaustive]` `DbKind`/`ForceMode`, and `MigrationStatus` field accessors.
   See the migrant_lib changelog. These are source-compatible for existing chained call sites
 
+### Removed
+- `migrant_lib`'s deprecated `d-sqlite`/`d-postgres`/`d-mysql`/`d-all` feature aliases. Use
+  `sqlite`/`postgres`/`mysql`/`all`
+
 ## [1.0.0-rc.1]
 ### Added
 - `--force` takes an optional mode: bare `--force` (or `--force=accept-failures`) records a

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -11,8 +11,7 @@ you only build the drivers you need.
 
 The library also has `all` to enable all three. No backend is enabled by
 default; invoking an operation whose feature is disabled returns
-`Error::FeatureRequired` rather than panicking. The pre-1.0 `d-sqlite` /
-`d-postgres` / `d-mysql` / `d-all` names remain as deprecated aliases.
+`Error::FeatureRequired` rather than panicking.
 
 ## SQLite
 

--- a/migrant_lib/CHANGELOG.md
+++ b/migrant_lib/CHANGELOG.md
@@ -17,6 +17,10 @@ Breaking pre-1.0 release, continuing the API cleanup from rc.1.
   must include a wildcard arm. This allows future backends and force modes to be added without a
   breaking change
 
+### Removed
+- The deprecated `d-sqlite`/`d-postgres`/`d-mysql`/`d-all` feature aliases. Use
+  `sqlite`/`postgres`/`mysql`/`all`
+
 ## [1.0.0-rc.1]
 Breaking pre-1.0 release. See the "Changed"/"Removed" sections for migration notes.
 

--- a/migrant_lib/CONTRIBUTING.md
+++ b/migrant_lib/CONTRIBUTING.md
@@ -31,7 +31,7 @@ disposable docker containers (see below).
 cargo test
 
 # sqlite only (bundled, no services needed)
-cargo test --features d-sqlite
+cargo test --features sqlite
 
 # everything, using throwaway docker databases for postgres/mysql
 ./test.sh

--- a/migrant_lib/Cargo.toml
+++ b/migrant_lib/Cargo.toml
@@ -47,12 +47,5 @@ mysql = ["dep:mysql"]
 all = ["sqlite", "postgres", "mysql"]
 vendored-openssl = ["native-tls?/vendored"]
 
-# Deprecated aliases for the pre-1.0 `d-*` feature names. Prefer the bare
-# names above; these will be removed in a future release.
-d-sqlite = ["sqlite"]
-d-postgres = ["postgres"]
-d-mysql = ["mysql"]
-d-all = ["all"]
-
 [package.metadata.docs.rs]
 features = ["all"]


### PR DESCRIPTION
- Remove the `d-sqlite`/`d-postgres`/`d-mysql`/`d-all` aliases from `migrant_lib`'s
  `[features]`. They were kept when the features were renamed in 1.0.0-rc.1; use
  `sqlite`/`postgres`/`mysql`/`all`
- Drop the alias note from `docs/src/backends.md` and use `--features sqlite` in
  `migrant_lib/CONTRIBUTING.md`
- Record the removal in both changelogs under 1.0.0-rc.2 (unreleased, so no version bump)
