### PR TITLE
mark prerelease versions as github prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,19 @@ jobs:
           pattern: dist-*
           path: dist
           merge-multiple: true
+      - name: Compute release kind
+        id: kind
+        run: |
+          version="${GITHUB_REF_NAME#cli-v}"
+          # Prereleases (e.g. rc/beta) carry a `-` in the semver.
+          case "$version" in
+            *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
       - name: Create release and upload binaries
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ steps.kind.outputs.prerelease }}
           files: |
             dist/migrant-*.tar.gz
             dist/migrant-*.zip


### PR DESCRIPTION
- Pass `prerelease` to `softprops/action-gh-release` in the `github-release` job, computed
  from the tag's semver the same way `docker-publish` decides whether to move `latest`:
  a `-` in the version (rc/beta) means a prerelease
- The existing `cli-v1.0.0-rc.1` and `cli-v1.0.0-rc.2` releases were flipped to prerelease
  by hand, so `Latest` no longer points at an rc
