### PR TITLE
bump actions to node 24 majors, update doc version pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -62,7 +62,7 @@ jobs:
       POSTGRES_TEST_CONN_STR: postgres://migrant:pass@localhost:5432/migrant_test
       MYSQL_TEST_CONN_STR: mysql://migrant:pass@localhost:3306/migrant_test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: test (no db features)
@@ -79,7 +79,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install mdBook
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -42,8 +42,8 @@ jobs:
           cp -r docs/landing/. _site/
           mkdir -p _site/guide
           cp -r docs/book/. _site/guide/
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -58,10 +58,10 @@ jobs:
       # first status poll. Retry once after a short settle so a transient backend
       # blip does not fail the run; a persistent failure still fails the retry.
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         continue-on-error: true
       - if: steps.deployment.outcome == 'failure'
         run: sleep 30
       - id: deployment_retry
         if: steps.deployment.outcome == 'failure'
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Verify tag matches crate version
         run: |
@@ -92,7 +92,7 @@ jobs:
             features: sqlite,postgres,mysql,update
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -130,7 +130,7 @@ jobs:
           Copy-Item README.md,LICENSE $name
           Compress-Archive -Path $name -DestinationPath "$name.zip"
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.target }}
           path: |
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           path: dist
@@ -163,7 +163,7 @@ jobs:
             *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
           esac
       - name: Create release and upload binaries
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ steps.kind.outputs.prerelease }}
           files: |
@@ -177,7 +177,7 @@ jobs:
     environment: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Compute image tags
         id: tags
         run: |
@@ -218,7 +218,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Wait for migrant_lib on crates.io
         run: |

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -48,7 +48,7 @@ Add `migrant_lib` to your project and enable a backend feature. See
 
 ```toml
 [dependencies]
-migrant_lib = { version = "1.0.0-rc.1", features = ["postgres"] }
+migrant_lib = { version = "1.0.0-rc.2", features = ["postgres"] }
 ```
 
 Next: the [Quickstart](quickstart.md).

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -6,7 +6,7 @@ backend feature (`sqlite`, `postgres`, `mysql`, or `all`):
 
 ```toml
 [dependencies]
-migrant_lib = { version = "1.0.0-rc.1", features = ["postgres"] }
+migrant_lib = { version = "1.0.0-rc.2", features = ["postgres"] }
 ```
 
 ## The pieces


### PR DESCRIPTION
- Bump the workflow actions off Node 20, which the runners now force onto Node 24:
  `actions/checkout` v4 -> v7, `upload-artifact` v4 -> v7, `download-artifact` v4 -> v8,
  `softprops/action-gh-release` v2 -> v3, `configure-pages` v5 -> v6,
  `upload-pages-artifact` v3 -> v5, `deploy-pages` v4 -> v5
- Every input in use (`name`/`path`/`if-no-files-found`/`overwrite`, `pattern`/`merge-multiple`,
  `files`/`prerelease`) is unchanged across these majors. `download-artifact` v8 now errors on a
  digest mismatch instead of warning, and `upload-artifact` v7 keeps zipping by default
- Update the `migrant_lib` version pins in `docs/src/install.md` and `docs/src/library.md`
  to 1.0.0-rc.2
